### PR TITLE
create spin around head example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_soloud_example/hello_flutter.dart';
 import 'package:flutter_soloud_example/page1.dart';
 import 'package:flutter_soloud_example/page2.dart';
 import 'package:flutter_soloud_example/page3.dart';
+import 'package:flutter_soloud_example/page4.dart';
 
 void main() {
   runApp(const MyApp());
@@ -28,8 +29,8 @@ class MyHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const DefaultTabController(
-      length: 4,
-      initialIndex: 3,
+      length: 5,
+      initialIndex: 4,
       child: SafeArea(
         child: Scaffold(
           body: Column(
@@ -42,6 +43,7 @@ class MyHomePage extends StatelessWidget {
                   Tab(text: 'visualizer'),
                   Tab(text: 'multi track'),
                   Tab(text: '3D audio'),
+                  Tab(text: 'Spining audio'),
                 ],
               ),
               SizedBox(height: 8),
@@ -53,6 +55,7 @@ class MyHomePage extends StatelessWidget {
                     Page1(),
                     Page2(),
                     Page3(),
+                    Page4(),
                   ],
                 ),
               ),

--- a/example/lib/page4.dart
+++ b/example/lib/page4.dart
@@ -1,0 +1,185 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_soloud/flutter_soloud.dart';
+import 'package:path_provider/path_provider.dart';
+
+class Page4 extends StatefulWidget {
+  const Page4({super.key});
+
+  @override
+  State<Page4> createState() => _Page4State();
+}
+
+class _Page4State extends State<Page4> {
+  SoundProps? currentSound;
+  late DateTime initialTime;
+  late final Timer timer;
+  Duration elapsed = Duration.zero;
+  double soundSpeed = 0.3;
+  double elapsedDistance = 0;
+  double circleRadius = 100;
+  double posX = 0;
+  double posY = 100;
+
+  @override
+  void initState() {
+    super.initState();
+    initialTime = DateTime.now();
+    timer = Timer.periodic(const Duration(milliseconds: 50), (_) {
+      if (currentSound != null) {
+        final now = DateTime.now();
+        SoLoud().set3dSourceParameters(
+          currentSound!.handle.first,
+          posX,
+          posY,
+          0,
+          0,
+          0,
+          0,
+        );
+        setState(() {
+          elapsed = now.difference(initialTime);
+          elapsedDistance += soundSpeed / 20;
+          final angle = 2 * pi * elapsedDistance;
+          posX = circleRadius * cos(angle);
+          posY = circleRadius * sin(angle);
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    SoLoud().stopIsolate();
+    SoLoud().stopCapture();
+    timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        ElevatedButton(
+          onPressed: () async {
+            if(currentSound == null){
+              await play(maxDistance: 100);
+            }else{
+              SoLoud().stop(currentSound!.handle.first);
+            }
+            setState(() {});
+          },
+          child: Text(currentSound == null ? 'play' : 'stop'),
+        ),
+        Text(elapsed.toString()),
+        const SizedBox(
+          height: 50,
+        ),
+        CustomPaint(
+          size: const Size.square(200),
+          painter: CircleWithDotPainter(x: posX, y: posY),
+        ),
+      ],
+    );
+  }
+
+  Future<void> play({required double maxDistance}) async {
+    /// Start audio engine if not already
+    if (!SoLoud().isIsolateRunning()) {
+      await SoLoud().startIsolate().then((value) {
+        if (value == PlayerErrors.noError) {
+          debugPrint('isolate started');
+        } else {
+          debugPrint('isolate starting error: $value');
+          return;
+        }
+      });
+    }
+
+    /// stop any previous sound loaded
+    if (currentSound != null) {
+      if (SoLoud().stopSound(currentSound!) != PlayerErrors.noError) {
+        return;
+      }
+    }
+
+    /// load the audio file
+    final f = await getAssetFile('assets/audio/8_bit_mentality.mp3');
+    final loadRet = await SoLoud().loadFile(f.path);
+    if (loadRet.error != PlayerErrors.noError) return;
+    currentSound = loadRet.sound;
+
+    /// play it
+    final playRet = await SoLoud().play3d(currentSound!, 0, 0, 0);
+    if (loadRet.error != PlayerErrors.noError) return;
+    SoLoud().setLooping(playRet.newHandle, true);
+    SoLoud().set3dSourceMinMaxDistance(
+      playRet.newHandle,
+      50,
+      maxDistance,
+    );
+    SoLoud().set3dSourceAttenuation(playRet.newHandle, 1, 1);
+    currentSound = playRet.sound;
+
+    if (mounted) setState(() {});
+  }
+
+  /// get the assets file and copy it to the temp dir
+  Future<File> getAssetFile(String assetsFile) async {
+    final tempDir = await getTemporaryDirectory();
+    final tempPath = tempDir.path;
+    final filePath = '$tempPath/$assetsFile';
+    final file = File(filePath);
+    if (file.existsSync()) {
+      return file;
+    } else {
+      final byteData = await rootBundle.load(assetsFile);
+      final buffer = byteData.buffer;
+      await file.create(recursive: true);
+      return file.writeAsBytes(
+        buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes),
+      );
+    }
+  }
+
+  void stopSound() {
+    SoLoud().pauseSwitch(currentSound!.handle.first);
+  }
+}
+
+class CircleWithDotPainter extends CustomPainter {
+  CircleWithDotPainter({required this.x, required this.y});
+
+  final double x;
+  final double y;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius = size.width / 2;
+    final circlePaint = Paint()
+      ..color = Colors.blue
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0;
+
+    final center = Offset(size.width / 2, size.height / 2);
+    canvas.drawCircle(center, radius, circlePaint);
+
+    final dotX = center.dx + x;
+    final dotY = center.dy + y;
+    final dotPaint = Paint()
+      ..color = Colors.red
+      ..style = PaintingStyle.fill;
+
+    final dotRadius = size.width / 50;
+    canvas.drawCircle(Offset(dotX, dotY), dotRadius, dotPaint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return false;
+  }
+}


### PR DESCRIPTION
Hope to explain well the problem:
the SoLoud().stop() in the stop button, just stop the handle and removes
the handle from the SoundProps [handle] list. So the sound 
remains and when you play it again a new SoundProps 
is created. And here the problem: I create the 
SoundProps.soundHash only with its fileName resulting in a 
duplicated sound. When you play again it will find the first 
sound with that soundHash which doesn't have the 
playing handle.

Recapping: 
- when you load() a new sound, a new SoundProps
  is created with its soundHash.
- when you play it, a new hadle is added to 
  [currentSound.handle] list
- when you stop() a handle, it will be removed from the list
- if instead you use stopSound(), currentSound will be
  removed from the internal list of sounds and all playing 
  handles of that SoundProps will stop
Using handles let the plugin play as many instances of the
same sound as you want without the latency needed to load it.

I need to fix the soundHash to do not let a new sound with the same hash to be created.
I also reverted the Soloud.stop() and stopSound(), now are
executed in the audioIsolate again.