### PR TITLE
Re-add logging to tests

### DIFF
--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -4,8 +4,17 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_soloud/flutter_soloud.dart';
+import 'package:logging/logging.dart';
 
+/// An end-to-end test.
+///
+/// Run this with `flutter run tests/tests.dart`.
 void main() async {
+  // Make sure we can see logs from the engine, even in release mode.
+  // ignore: avoid_print
+  Logger.root.onRecord.listen(print);
+  Logger.root.level = Level.ALL;
+
   WidgetsFlutterBinding.ensureInitialized();
 
   await runZonedGuarded(


### PR DESCRIPTION
## Description

The end-to-end test in `example/tests` relies on the developer reading logs. This re-adds the information that was swallowed by `package:logging`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
