### PR TITLE
Improve initialization and shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   See `README.md` to learn how to capture log messages and how to filter
   them.
 - Renamed `SoLoud.startIsolate()` to `SoLoud.initialize()`
-- Renamed `SoLoud.stopIsolate()` to `SoLoud.dispose()`
+- Renamed `SoLoud.stopIsolate()` to `SoLoud.shutdown()`
 - Removed `SoLoud.initEngine()` (it shouldn't be called manually)
 - None of the renaming changes are strictly breaking (yet). 
   The old method names still exist as aliases to the new names, and are
@@ -26,6 +26,20 @@
   _extend_ it. This reduces the
   [fragile base class problem](https://en.wikipedia.org/wiki/Fragile_base_class)
   and makes the API easier to evolve.
+- Added a new, more usable way of finding out whether the audio engine
+  is initialized and ready to use:
+    - `SoLoud.initialized` (returns a future, safe to check during initialization)
+      - This is a much easier way to check engine readiness than
+        subscribing to `SoLoud.audioEvents` and waiting for 
+        the `isolateStarted` event.
+    - `SoLoud.isInitialized` (returns synchronously)
+    - previous methods to check readiness (`isPlayerInited` and `isIsolateRunning()`)
+      are now deprecated
+- `SoLoud.initialize()` can now be safely called during engine
+  shutdown. It will wait for the engine to shut down before
+  re-initializing it. Same for `SoLoud.shutdown()`, which will 
+  wait for the engine to initialize before shutting it down,
+  to avoid various race conditions.
 
 #### 1.2.5 (2 Mar 2024)
 - updated mp3, flac and wav decoders

--- a/example/lib/controls.dart
+++ b/example/lib/controls.dart
@@ -17,7 +17,7 @@ class Controls extends StatefulWidget {
 class _ControlsState extends State<Controls> {
   static final Logger _log = Logger('_ControlsState');
 
-  final isAudioIsolateRunning = ValueNotifier<bool>(false);
+  final isInitialized = ValueNotifier<bool>(false);
   final isCaptureRunning = ValueNotifier<bool>(false);
   late final List<CaptureDevice> captureDevices;
   int choosenCaptureDeviceId = -1;
@@ -37,7 +37,7 @@ class _ControlsState extends State<Controls> {
 
   @override
   void reassemble() {
-    isAudioIsolateRunning.value = SoLoud.instance.isIsolateRunning();
+    isInitialized.value = SoLoud.instance.isInitialized;
     isCaptureRunning.value = SoLoudCapture.instance.isCaptureStarted();
     super.reassemble();
   }
@@ -47,7 +47,7 @@ class _ControlsState extends State<Controls> {
     // TODO(filiph): remove this listener - it starts listening on every build
     SoLoud.instance.audioEvent.stream.listen(
       (event) {
-        isAudioIsolateRunning.value = SoLoud.instance.isIsolateRunning();
+        isInitialized.value = SoLoud.instance.isInitialized;
         isCaptureRunning.value = SoLoudCapture.instance.isCaptureStarted();
       },
     );
@@ -58,13 +58,13 @@ class _ControlsState extends State<Controls> {
           children: [
             /// AudioIsolate
             ValueListenableBuilder<bool>(
-              valueListenable: isAudioIsolateRunning,
+              valueListenable: isInitialized,
               builder: (_, isRunning, __) {
                 return ElevatedButton(
                   onPressed: () async {
                     if (isRunning) {
                       /// this will stop also the engine and the loop
-                      final b = await SoLoud.instance.dispose();
+                      final b = await SoLoud.instance.shutdown();
                       if (b) {
                         _log.info('isolate stopped');
                       }

--- a/example/lib/main_wav_stream.dart
+++ b/example/lib/main_wav_stream.dart
@@ -109,7 +109,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> stop() async {
-    await SoLoud.instance.dispose();
+    await SoLoud.instance.shutdown();
     SoLoudCapture.instance.stopCapture();
     sounds.clear();
   }

--- a/example/lib/page_3d_audio.dart
+++ b/example/lib/page_3d_audio.dart
@@ -20,7 +20,7 @@ class _Page3DAudioState extends State<Page3DAudio> {
 
   @override
   void dispose() {
-    SoLoud.instance.dispose();
+    SoLoud.instance.shutdown();
     SoLoudCapture.instance.stopCapture();
     super.dispose();
   }
@@ -64,7 +64,7 @@ class _Page3DAudioState extends State<Page3DAudio> {
   ///
   Future<void> playFromUrl() async {
     /// Start audio engine if not already
-    if (!SoLoud.instance.isIsolateRunning()) {
+    if (!await SoLoud.instance.initialized) {
       await SoLoud.instance.initialize().then((value) {
         if (value == PlayerErrors.noError) {
           _log.info('isolate started');
@@ -104,7 +104,7 @@ class _Page3DAudioState extends State<Page3DAudio> {
   ///
   Future<void> play(double maxDistance) async {
     /// Start audio engine if not already
-    if (!SoLoud.instance.isIsolateRunning()) {
+    if (!await SoLoud.instance.initialized) {
       await SoLoud.instance.initialize().then((value) {
         if (value == PlayerErrors.noError) {
           _log.info('isolate started');

--- a/example/lib/page_hello_flutter.dart
+++ b/example/lib/page_hello_flutter.dart
@@ -24,7 +24,7 @@ class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
 
   @override
   void dispose() {
-    SoLoud.instance.dispose();
+    SoLoud.instance.shutdown();
     SoLoudCapture.instance.stopCapture();
     super.dispose();
   }
@@ -84,7 +84,7 @@ class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
   /// play file
   Future<void> play(String file) async {
     /// Start audio engine if not already
-    if (!SoLoud.instance.isIsolateRunning()) {
+    if (!await SoLoud.instance.initialized) {
       await SoLoud.instance.initialize().then((value) {
         if (value == PlayerErrors.noError) {
           _log.info('engine started');

--- a/example/lib/page_multi_track.dart
+++ b/example/lib/page_multi_track.dart
@@ -22,7 +22,7 @@ class _PageMultiTrackState extends State<PageMultiTrack> {
 
   @override
   void dispose() {
-    SoLoud.instance.dispose();
+    SoLoud.instance.shutdown();
     SoLoudCapture.instance.stopCapture();
     super.dispose();
   }

--- a/example/lib/page_visualizer.dart
+++ b/example/lib/page_visualizer.dart
@@ -55,7 +55,7 @@ class _PageVisualizerState extends State<PageVisualizer> {
 
   @override
   void dispose() {
-    SoLoud.instance.dispose();
+    SoLoud.instance.shutdown();
     SoLoudCapture.instance.stopCapture();
     super.dispose();
   }

--- a/example/lib/page_waveform.dart
+++ b/example/lib/page_waveform.dart
@@ -53,7 +53,7 @@ class _PageWaveformState extends State<PageWaveform> {
 
   @override
   void dispose() {
-    SoLoud.instance.dispose();
+    SoLoud.instance.shutdown();
     SoLoudCapture.instance.stopCapture();
     super.dispose();
   }
@@ -74,7 +74,7 @@ class _PageWaveformState extends State<PageWaveform> {
 
   @override
   Widget build(BuildContext context) {
-    if (!SoLoud.instance.isPlayerInited) return const SizedBox.shrink();
+    if (!SoLoud.instance.isInitialized) return const SizedBox.shrink();
 
     return Scaffold(
       body: SingleChildScrollView(

--- a/example/lib/visualizer/visualizer.dart
+++ b/example/lib/visualizer/visualizer.dart
@@ -84,7 +84,7 @@ class Visualizer extends StatefulWidget {
 
 class _VisualizerState extends State<Visualizer>
     with SingleTickerProviderStateMixin {
-  late bool isPlayerInited;
+  late bool isInitialized;
   late bool isCaptureInited;
   late Ticker ticker;
   late Stopwatch sw;
@@ -103,11 +103,11 @@ class _VisualizerState extends State<Visualizer>
   void initState() {
     super.initState();
 
-    isPlayerInited = SoLoud.instance.isPlayerInited;
+    isInitialized = SoLoud.instance.isInitialized;
     isCaptureInited = SoLoudCapture.instance.isCaptureInited;
     SoLoud.instance.audioEvent.stream.listen(
       (event) {
-        isPlayerInited = SoLoud.instance.isPlayerInited;
+        isInitialized = SoLoud.instance.isInitialized;
         isCaptureInited = SoLoudCapture.instance.isCaptureInited;
       },
     );
@@ -329,7 +329,7 @@ class _VisualizerState extends State<Visualizer>
     }
 
     /// get audio data from player or capture device
-    if (widget.controller.isVisualizerForPlayer && isPlayerInited) {
+    if (widget.controller.isVisualizerForPlayer && isInitialized) {
       final ret = SoLoud.instance.getAudioTexture2D(playerData);
       if (ret != PlayerErrors.noError) return null;
     } else if (!widget.controller.isVisualizerForPlayer && isCaptureInited) {
@@ -381,7 +381,7 @@ class _VisualizerState extends State<Visualizer>
     }
 
     /// get audio data from player or capture device
-    if (widget.controller.isVisualizerForPlayer && isPlayerInited) {
+    if (widget.controller.isVisualizerForPlayer && isInitialized) {
       final ret = SoLoud.instance.getAudioTexture2D(playerData);
       if (ret != PlayerErrors.noError) return null;
     } else if (!widget.controller.isVisualizerForPlayer && isCaptureInited) {

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -56,19 +56,22 @@ void main() async {
 
   if (exitCode != 0) {
     // Since we're running this inside `flutter run`, the exit code
-    // will be overridden to 1 by the flutter tool.
-    // The following is making sure that the errors aren't lost.
+    // will be overridden to 0 by the Flutter tool.
+    // The following is making sure that the errors are noticed.
     stderr
-      ..writeln('===== TEST FAILED with the following error(s) =====')
+      ..writeln('===== TESTS FAILED with the following error(s) =====')
       ..writeln()
       ..writeln(errorsBuffer.toString())
       ..writeln()
       ..writeln('See logs above for details.')
       ..writeln();
   } else {
-    debugPrint('===== TEST PASSED! =====');
+    stdout
+      ..writeln('===== TESTS PASSED! =====')
+      ..writeln();
   }
 
+  // Cleanly close the app.
   await SystemChannels.platform.invokeMethod('SystemNavigator.pop');
 }
 
@@ -193,8 +196,6 @@ Future<void> test1() async {
       'Sound end playback event not triggered!',
     );
   }
-
-  Logger('test1').warning('test warning!');
 
   /// Play 4 sample
   {

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_soloud/flutter_soloud.dart';
 import 'package:logging/logging.dart';
 
@@ -12,7 +13,17 @@ import 'package:logging/logging.dart';
 void main() async {
   // Make sure we can see logs from the engine, even in release mode.
   // ignore: avoid_print
-  Logger.root.onRecord.listen(print);
+  final errorsBuffer = StringBuffer();
+  Logger.root.onRecord.listen((record) {
+    debugPrint(record.toString(), wrapWidth: 80);
+    if (record.level >= Level.WARNING) {
+      // Make sure the warnings are visible.
+      stderr.writeln('TEST error: $record');
+      errorsBuffer.writeln('- $record');
+      // Set exit code but keep running to see all logs.
+      exitCode = 1;
+    }
+  });
   Logger.root.level = Level.ALL;
 
   WidgetsFlutterBinding.ensureInitialized();
@@ -20,29 +31,45 @@ void main() async {
   await runZonedGuarded(
     () async => test3(),
     (error, stack) {
-      debugPrint('TEST error: $error\nstack: $stack');
-      exit(1);
+      stderr.writeln('TEST error: $error\nstack: $stack');
+      exitCode = 1;
     },
   );
 
   await runZonedGuarded(
     () async => test1(),
     (error, stack) {
-      debugPrint('TEST error: $error\nstack: $stack');
-      exit(1);
+      stderr.writeln('TEST error: $error\nstack: $stack');
+      exitCode = 1;
     },
   );
 
   await runZonedGuarded(
     () async => test2(),
     (error, stack) {
-      debugPrint('TEST error: $error\nstack: $stack');
-      exit(1);
+      stderr.writeln('TEST error: $error\nstack: $stack');
+      exitCode = 1;
     },
   );
 
-  debugPrint('TEST passed!');
-  exit(0);
+  stdout.write('\n\n\n---\n\n\n');
+
+  if (exitCode != 0) {
+    // Since we're running this inside `flutter run`, the exit code
+    // will be overridden to 1 by the flutter tool.
+    // The following is making sure that the errors aren't lost.
+    stderr
+      ..writeln('===== TEST FAILED with the following error(s) =====')
+      ..writeln()
+      ..writeln(errorsBuffer.toString())
+      ..writeln()
+      ..writeln('See logs above for details.')
+      ..writeln();
+  } else {
+    debugPrint('===== TEST PASSED! =====');
+  }
+
+  await SystemChannels.platform.invokeMethod('SystemNavigator.pop');
 }
 
 String output = '';
@@ -167,6 +194,8 @@ Future<void> test1() async {
     );
   }
 
+  Logger('test1').warning('test warning!');
+
   /// Play 4 sample
   {
     await SoLoud.instance.play(currentSound!);
@@ -207,7 +236,7 @@ Future<void> initialize() async {
 }
 
 Future<void> dispose() async {
-  final ret = await SoLoud.instance.dispose();
+  final ret = await SoLoud.instance.shutdown();
   assert(ret, 'dispose() failed!');
 }
 

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -9,9 +9,42 @@
 version: 1
 
 transforms:
+  # PlayerErrors.isolateAlreadyStarted => SoLoudCapture.multipleInitialization
+  - title: "Rename to 'multipleInitialization'"
+    date: 2024-03-09
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      constant: 'isolateAlreadyStarted'
+      inEnum: 'PlayerErrors'
+    changes:
+      - kind: 'rename'
+        newName: 'multipleInitialization'
+
+  # SoLoud.isPlayerInited => SoLoudCapture.isReady
+  - title: "Rename to 'isInitialized'"
+    date: 2024-03-09
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      getter: 'isPlayerInited'
+      inClass: 'SoLoud'
+    changes:
+      - kind: 'rename'
+        newName: 'isInitialized'
+
+  # SoLoud.dispose => SoLoudCapture.shutdown
+  - title: "Rename to 'shutdown()'"
+    date: 2024-03-09
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      method: 'dispose'
+      inClass: 'SoLoud'
+    changes:
+      - kind: 'rename'
+        newName: 'shutdown'
+
   # SoLoudCapture.initCapture => SoLoudCapture.initialize
   - title: "Rename to 'initialize()'"
-    date: 2024-03-08
+    date: 2024-03-09
     element:
       uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
       method: 'initCapture'

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -86,13 +86,25 @@ enum PlayerErrors {
   backendNotInited,
 
   /// Audio isolate already started
+  @Deprecated('Use multipleInitialization instead')
   isolateAlreadyStarted,
+
+  /// Engine has already been initialized successfully
+  /// but a new call to `initialize()` was made.
+  multipleInitialization,
+
+  /// Engine is currently being initialized
+  /// and another call to `initialize()` was made.
+  concurrentInitialization,
 
   /// Audio isolate not yet started
   isolateNotStarted,
 
   /// Engine not yet started
   engineNotInited,
+
+  /// The engine took too long to initialize.
+  engineInitializationTimedOut,
 
   /// Filter not found
   filterNotFound;
@@ -126,12 +138,24 @@ enum PlayerErrors {
         return 'The sound with specified hash is not found';
       case PlayerErrors.backendNotInited:
         return 'Player not initialized';
+      // ignore: deprecated_member_use_from_same_package
       case PlayerErrors.isolateAlreadyStarted:
         return 'Audio isolate already started';
+      case PlayerErrors.multipleInitialization:
+        return 'Engine has already been initialized successfully '
+            'but a new call to initialize() was made';
+      case PlayerErrors.concurrentInitialization:
+        return 'Engine is currently being initialized '
+            'and another call to initialize() was made';
       case PlayerErrors.isolateNotStarted:
         return 'Audio isolate not yet started';
       case PlayerErrors.engineNotInited:
-        return 'Engine not yet started';
+        return 'Engine not yet started. '
+            'Either asynchronously await `SoLoud.ready` '
+            'or synchronously check `SoLoud.isReady` '
+            'before calling the function.';
+      case PlayerErrors.engineInitializationTimedOut:
+        return 'Engine initialization timed out';
       case PlayerErrors.filterNotFound:
         return 'Filter not found';
     }

--- a/lib/src/soloud_capture.dart
+++ b/lib/src/soloud_capture.dart
@@ -5,11 +5,21 @@ import 'package:flutter_soloud/src/enums.dart';
 import 'package:flutter_soloud/src/soloud.dart';
 import 'package:flutter_soloud/src/soloud_controller.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 
 /// Use this class to _capture_ audio (such as from a microphone).
 ///
 /// This class is completely independent from [SoLoud]. You can
 /// initialize and shut it down regardless of the state of [SoLoud].
+///
+/// Please note that this class does _not_ currently provide
+/// recording capabilities. It allows you to provide stats and visualizations
+/// of the audio data coming from a capture device (such as microphone)
+/// but it currently does not allow you to save that data to a file.
+///
+/// This class is marked as [experimental] and therefore may have
+/// breaking changes in the future without a major version bump.
+@experimental
 interface class SoLoudCapture {
   /// A deprecated way to access the singleton [instance] of [SoLoudCapture].
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   http: ^1.1.0
   #https://pub.dev/packages/logging
   logging: ^1.0.0
+  #https://pub.dev/packages/meta
+  meta: ^1.0.0
   #https://pub.dev/packages/path_provider
   path_provider: ^2.0.15
   

--- a/test_fixes/playererrors_multipleinitialization.dart
+++ b/test_fixes/playererrors_multipleinitialization.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_soloud/flutter_soloud.dart';
+
+PlayerErrors error = PlayerErrors.isolateAlreadyStarted;

--- a/test_fixes/playererrors_multipleinitialization.dart.expect
+++ b/test_fixes/playererrors_multipleinitialization.dart.expect
@@ -1,0 +1,3 @@
+import 'package:flutter_soloud/flutter_soloud.dart';
+
+PlayerErrors error = PlayerErrors.multipleInitialization;

--- a/test_fixes/soloud_disposal.dart
+++ b/test_fixes/soloud_disposal.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
-  final soloud = SoLoud();
-  await soloud.startIsolate();
+  await SoLoud.instance.stopIsolate();
+  await SoLoud.instance.dispose();
 }

--- a/test_fixes/soloud_disposal.dart.expect
+++ b/test_fixes/soloud_disposal.dart.expect
@@ -1,6 +1,6 @@
 import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
-  final soloud = SoLoud();
-  await soloud.startIsolate();
+  await SoLoud.instance.shutdown();
+  await SoLoud.instance.shutdown();
 }

--- a/test_fixes/soloud_initialization.dart.expect
+++ b/test_fixes/soloud_initialization.dart.expect
@@ -3,5 +3,4 @@ import 'package:flutter_soloud/flutter_soloud.dart';
 Future<void> main() async {
   final soloud = SoLoud();
   await soloud.initialize();
-  await soloud.dispose();
 }

--- a/test_fixes/soloud_is_initialized.dart
+++ b/test_fixes/soloud_is_initialized.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
-  final soloud = SoLoud();
-  await soloud.startIsolate();
+  final ready = SoLoud.instance.isPlayerInited;
 }

--- a/test_fixes/soloud_is_initialized.dart.expect
+++ b/test_fixes/soloud_is_initialized.dart.expect
@@ -1,6 +1,5 @@
 import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
-  final soloud = SoLoud();
-  await soloud.startIsolate();
+  final ready = SoLoud.instance.isInitialized;
 }


### PR DESCRIPTION
## Description

- Renamed `SoLoud.stopIsolate()` (a.k.a. `SoLoud.dispose()`) to `SoLoud.shutdown()`
- Added a new, more usable way of finding out whether the audio engine
  is initialized and ready to use:
    - `SoLoud.initialized` (returns a future, safe to check during initialization)
      - This is a much easier way to check engine readiness than
        subscribing to `SoLoud.audioEvents` and waiting for 
        the `isolateStarted` event.
    - `SoLoud.isInitialized` (returns synchronously)
    - previous methods to check readiness (`isPlayerInited` and `isIsolateRunning()`)
      are now deprecated
- `SoLoud.initialize()` can now be safely called during engine
  shutdown. It will wait for the engine to shut down before
  re-initializing it. Same for `SoLoud.shutdown()`, which will 
  wait for the engine to initialize before shutting it down,
  to avoid various race conditions.

Plus some improvements to the manual test at `example/tests`.

Also marked `SoLoudCapture` as `@experimental`, so that we are free to evolve that API without major version bump.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
