### PR TITLE
fix error when getting wave/FFT audio data while closing and reinit the player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-#### 1.2.xx
+#### 2.xx.yy
+- added `bool SoLoud.getVisualizationEnabled()` to get the current state of the visualization.
 - added `mode` property to `SoLoud.loadFile()` and `SoloudTools.loadFrom*` to prevent to load the whole audio data into memory:
     - *LoadMode.memory* by default. Means less CPU, more memory allocated.
     - *LoadMode.disk* means more CPU, less memory allocated. Lags can occurs while seeking MP3s, especially when using a slider.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The `AudioIsolate` instance has the duty of receiving commands and sending them 
 | **setVolume**| ({PlayerErrors error, double volume})| `int` handle, `double` volume| set  [handle] volume.|
 | **getIsValidVoiceHandle**| ({PlayerErrors error, bool isValid})| `int` handle| Check if a handle is still valid.|
 | **setVisualizationEnabled**| -| `bool` enabled| Enable or disable getting data from `getFft`, `getWave`, `getAudioTexture*`.|
+| **getVisualizationEnabled**| ({PlayerErrors error, bool isEnabled})| -| Get the state of visualization flag.|
 | **getFft**| -| `Pointer<Float>` fft| Returns a 256 float array containing FFT data.|
 | **getWave**| -| `Pointer<Float>` wave| Returns a 256 float array containing wave data (magnitudes).|
 | **getAudioTexture**| -| `Pointer<Float>` samples| Returns in `samples` a 512 float array.<br/>- The first 256 floats represent the FFT frequencies data [>=0.0].<br/>- The other 256 floats represent the wave data (amplitude) [-1.0~1.0].|

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_soloud/flutter_soloud.dart';
 import 'package:flutter_soloud_example/controls.dart';
 import 'package:flutter_soloud_example/page_3d_audio.dart';
 import 'package:flutter_soloud_example/page_hello_flutter.dart';
@@ -54,19 +55,23 @@ class MyHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const DefaultTabController(
+    return DefaultTabController(
       length: 5,
       initialIndex: 4,
       child: SafeArea(
         child: Scaffold(
           body: Column(
             children: [
-              Controls(),
+              const Controls(),
               SingleChildScrollView(
                 scrollDirection: Axis.horizontal,
                 child: TabBar(
+                  onTap: (value) {
+                    debugPrint('ON TAP');
+                    // SoLoud.instance.shutdown();
+                  },
                   isScrollable: true,
-                  tabs: [
+                  tabs: const [
                     Tab(text: 'hello world!'),
                     Tab(text: 'visualizer'),
                     Tab(text: 'multi track'),
@@ -75,8 +80,8 @@ class MyHomePage extends StatelessWidget {
                   ],
                 ),
               ),
-              SizedBox(height: 8),
-              Expanded(
+              const SizedBox(height: 8),
+              const Expanded(
                 child: TabBarView(
                   physics: NeverScrollableScrollPhysics(),
                   children: [

--- a/example/lib/page_3d_audio.dart
+++ b/example/lib/page_3d_audio.dart
@@ -23,14 +23,14 @@ class _Page3DAudioState extends State<Page3DAudio> {
   void initState() {
     super.initState();
 
-    /// Ensure the player is down
-    if (SoLoud.instance.isInitialized) {
-      SoLoud.instance.shutdown();
-    }
-
-    /// Reinitialize the player
+    /// Initialize the player
+    _log.info('player starting');
     SoLoud.instance.initialize().then((value) {
-      if (value == PlayerErrors.noError) {
+      if (value == PlayerErrors.multipleInitialization) {
+        SoLoud.instance.disposeAllSound();
+      }
+      if (value == PlayerErrors.noError ||
+          value == PlayerErrors.multipleInitialization) {
         _log.info('player started');
         SoLoud.instance.setVisualizationEnabled(false);
         SoLoud.instance.setGlobalVolume(1);
@@ -46,7 +46,7 @@ class _Page3DAudioState extends State<Page3DAudio> {
   @override
   Widget build(BuildContext context) {
     if (!SoLoud.instance.isInitialized) return const SizedBox.shrink();
-    
+
     return Scaffold(
       body: Center(
         child: Column(

--- a/example/lib/page_3d_audio.dart
+++ b/example/lib/page_3d_audio.dart
@@ -34,8 +34,11 @@ class _Page3DAudioState extends State<Page3DAudio> {
         _log.info('player started');
         SoLoud.instance.setVisualizationEnabled(false);
         SoLoud.instance.setGlobalVolume(1);
-        canBuild = true;
-        if (context.mounted) setState(() {});
+        if (context.mounted) {
+          setState(() {
+            canBuild = true;
+          });
+        }
       } else {
         _log.severe('player starting error: $value');
         return;

--- a/example/lib/page_hello_flutter.dart
+++ b/example/lib/page_hello_flutter.dart
@@ -26,15 +26,14 @@ class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
   @override
   void initState() {
     super.initState();
-    
-    /// Ensure the player is down
-    if (SoLoud.instance.isInitialized) {
-      SoLoud.instance.shutdown();
-    }
 
-    /// Reinitialize the player
+    /// Initialize the player
     SoLoud.instance.initialize().then((value) {
-      if (value == PlayerErrors.noError) {
+      if (value == PlayerErrors.multipleInitialization) {
+        SoLoud.instance.disposeAllSound();
+      }
+      if (value == PlayerErrors.noError ||
+          value == PlayerErrors.multipleInitialization) {
         _log.info('player started');
         // SoLoud.instance.setVisualizationEnabled(false);
         SoLoud.instance.setGlobalVolume(1);

--- a/example/lib/page_hello_flutter.dart
+++ b/example/lib/page_hello_flutter.dart
@@ -21,16 +21,36 @@ class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
   static final Logger _log = Logger('_PageHelloFlutterSoLoudState');
 
   SoundProps? currentSound;
+  bool canBuild = false;
 
   @override
-  void dispose() {
-    SoLoud.instance.shutdown();
-    SoLoudCapture.instance.stopCapture();
-    super.dispose();
+  void initState() {
+    super.initState();
+    
+    /// Ensure the player is down
+    if (SoLoud.instance.isInitialized) {
+      SoLoud.instance.shutdown();
+    }
+
+    /// Reinitialize the player
+    SoLoud.instance.initialize().then((value) {
+      if (value == PlayerErrors.noError) {
+        _log.info('player started');
+        // SoLoud.instance.setVisualizationEnabled(false);
+        SoLoud.instance.setGlobalVolume(1);
+        canBuild = true;
+        if (context.mounted) setState(() {});
+      } else {
+        _log.severe('player starting error: $value');
+        return;
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
+    if (!SoLoud.instance.isInitialized) return const SizedBox.shrink();
+
     return Scaffold(
       body: Center(
         child: Column(

--- a/example/lib/page_hello_flutter.dart
+++ b/example/lib/page_hello_flutter.dart
@@ -37,8 +37,11 @@ class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
         _log.info('player started');
         // SoLoud.instance.setVisualizationEnabled(false);
         SoLoud.instance.setGlobalVolume(1);
-        canBuild = true;
-        if (context.mounted) setState(() {});
+        if (context.mounted) {
+          setState(() {
+            canBuild = true;
+          });
+        }
       } else {
         _log.severe('player starting error: $value');
         return;

--- a/example/lib/page_multi_track.dart
+++ b/example/lib/page_multi_track.dart
@@ -22,15 +22,14 @@ class _PageMultiTrackState extends State<PageMultiTrack> {
   @override
   void initState() {
     super.initState();
-    
-    /// Ensure the player is down
-    if (SoLoud.instance.isInitialized) {
-      SoLoud.instance.shutdown();
-    }
 
-    /// Reinitialize the player
+    /// Initialize the player
     SoLoud.instance.initialize().then((value) {
-      if (value == PlayerErrors.noError) {
+      if (value == PlayerErrors.multipleInitialization) {
+        SoLoud.instance.disposeAllSound();
+      }
+      if (value == PlayerErrors.noError ||
+          value == PlayerErrors.multipleInitialization) {
         _log.info('player started');
         // SoLoud.instance.setVisualizationEnabled(false);
         SoLoud.instance.setGlobalVolume(1);

--- a/example/lib/page_multi_track.dart
+++ b/example/lib/page_multi_track.dart
@@ -33,8 +33,11 @@ class _PageMultiTrackState extends State<PageMultiTrack> {
         _log.info('player started');
         // SoLoud.instance.setVisualizationEnabled(false);
         SoLoud.instance.setGlobalVolume(1);
-        canBuild = true;
-        if (context.mounted) setState(() {});
+        if (context.mounted) {
+          setState(() {
+            canBuild = true;
+          });
+        }
       } else {
         _log.severe('player starting error: $value');
         return;

--- a/example/lib/page_multi_track.dart
+++ b/example/lib/page_multi_track.dart
@@ -15,20 +15,38 @@ class PageMultiTrack extends StatefulWidget {
 }
 
 class _PageMultiTrackState extends State<PageMultiTrack> {
+  static final Logger _log = Logger('_PageMultiTrackState');
+
+  bool canBuild = false;
+
   @override
   void initState() {
     super.initState();
-  }
+    
+    /// Ensure the player is down
+    if (SoLoud.instance.isInitialized) {
+      SoLoud.instance.shutdown();
+    }
 
-  @override
-  void dispose() {
-    SoLoud.instance.shutdown();
-    SoLoudCapture.instance.stopCapture();
-    super.dispose();
+    /// Reinitialize the player
+    SoLoud.instance.initialize().then((value) {
+      if (value == PlayerErrors.noError) {
+        _log.info('player started');
+        // SoLoud.instance.setVisualizationEnabled(false);
+        SoLoud.instance.setGlobalVolume(1);
+        canBuild = true;
+        if (context.mounted) setState(() {});
+      } else {
+        _log.severe('player starting error: $value');
+        return;
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
+    if (!SoLoud.instance.isInitialized) return const SizedBox.shrink();
+
     return const Scaffold(
       body: Padding(
         padding: EdgeInsets.only(top: 50, right: 8, left: 8),

--- a/example/lib/page_visualizer.dart
+++ b/example/lib/page_visualizer.dart
@@ -43,7 +43,7 @@ class _PageVisualizerState extends State<PageVisualizer> {
       ValueNotifier(TextureType.fft2D);
   final ValueNotifier<double> fftSmoothing = ValueNotifier(0.8);
   final ValueNotifier<bool> isVisualizerForPlayer = ValueNotifier(true);
-  late final ValueNotifier<bool> isVisualizerEnabled = ValueNotifier(true);
+  final ValueNotifier<bool> isVisualizerEnabled = ValueNotifier(true);
   final ValueNotifier<RangeValues> fftImageRange =
       ValueNotifier(const RangeValues(0, 255));
   final ValueNotifier<int> maxFftImageRange = ValueNotifier(255);
@@ -58,14 +58,13 @@ class _PageVisualizerState extends State<PageVisualizer> {
   void initState() {
     super.initState();
 
-    /// Ensure the player is down
-    if (SoLoud.instance.isInitialized) {
-      SoLoud.instance.shutdown();
-    }
-
-    /// Reinitialize the player
+    /// Initialize the player
     SoLoud.instance.initialize().then((value) {
-      if (value == PlayerErrors.noError) {
+      if (value == PlayerErrors.multipleInitialization) {
+        SoLoud.instance.disposeAllSound();
+      }
+      if (value == PlayerErrors.noError ||
+          value == PlayerErrors.multipleInitialization) {
         _log.info('player started');
         SoLoud.instance.setVisualizationEnabled(true);
         SoLoud.instance.setGlobalVolume(1);

--- a/example/lib/page_visualizer.dart
+++ b/example/lib/page_visualizer.dart
@@ -68,8 +68,11 @@ class _PageVisualizerState extends State<PageVisualizer> {
         _log.info('player started');
         SoLoud.instance.setVisualizationEnabled(true);
         SoLoud.instance.setGlobalVolume(1);
-        canBuild = true;
-        if (context.mounted) setState(() {});
+        if (context.mounted) {
+          setState(() {
+            canBuild = true;
+          });
+        }
       } else {
         _log.severe('player starting error: $value');
         return;

--- a/example/lib/page_waveform.dart
+++ b/example/lib/page_waveform.dart
@@ -56,8 +56,11 @@ class _PageWaveformState extends State<PageWaveform> {
 
         /// Only when the [notes] are set up, build the UI
         setupNotes().then((value) {
-          canBuild = true;
-          if (context.mounted) setState(() {});
+          if (context.mounted) {
+          setState(() {
+            canBuild = true;
+          });
+        }
         });
       } else {
         _log.severe('player starting error: $value');

--- a/example/lib/page_waveform.dart
+++ b/example/lib/page_waveform.dart
@@ -42,17 +42,18 @@ class _PageWaveformState extends State<PageWaveform> {
   void initState() {
     super.initState();
 
-    /// Ensure the player is down
-    if (SoLoud.instance.isInitialized) {
-      SoLoud.instance.shutdown();
-    }
-
-    /// Reinitialize the player
+    /// Initialize the player
+    _log.info('player starting');
     SoLoud.instance.initialize().then((value) {
-      if (value == PlayerErrors.noError) {
+      if (value == PlayerErrors.multipleInitialization) {
+        SoLoud.instance.disposeAllSound();
+      }
+      if (value == PlayerErrors.noError ||
+          value == PlayerErrors.multipleInitialization) {
         _log.info('player started');
         SoLoud.instance.setVisualizationEnabled(true);
         SoLoud.instance.setGlobalVolume(0.6);
+
         /// Only when the [notes] are set up, build the UI
         setupNotes().then((value) {
           canBuild = true;

--- a/example/lib/visualizer/visualizer.dart
+++ b/example/lib/visualizer/visualizer.dart
@@ -32,7 +32,7 @@ class FftController extends ChangeNotifier {
     this.minFreqRange = 0,
     this.maxFreqRange = 255,
     this.isVisualizerEnabled = true,
-    this.isVisualizerForPlayer = false,
+    this.isVisualizerForPlayer = true,
   });
 
   int minFreqRange;

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -457,6 +457,19 @@ class FlutterSoLoudFfi {
   late final _setVisualizationEnabled =
       _setVisualizationEnabledPtr.asFunction<void Function(int)>();
 
+  /// Get visualization state
+  ///
+  /// Return true if enabled
+  bool getVisualizationEnabled() {
+    return _getVisualizationEnabled() == 1;
+  }
+
+  late final _getVisualizationEnabledPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function()>>(
+          'getVisualizationEnabled');
+  late final _getVisualizationEnabled =
+      _getVisualizationEnabledPtr.asFunction<int Function()>();
+
   /// Returns valid data only if VisualizationEnabled is true
   ///
   /// [fft]

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -107,7 +107,10 @@ enum PlayerErrors {
   engineInitializationTimedOut,
 
   /// Filter not found
-  filterNotFound;
+  filterNotFound,
+
+  /// asking for wave and FFT is not enableb
+  visualizationNotEnabled;
 
   /// Returns a human-friendly sentence describing the error.
   String get _asSentence {
@@ -158,6 +161,9 @@ enum PlayerErrors {
         return 'Engine initialization timed out';
       case PlayerErrors.filterNotFound:
         return 'Filter not found';
+      case PlayerErrors.visualizationNotEnabled:
+        return 'Asking for audio data is not enabled! Please use '
+        '`setVisualizationEnabled(true);` to enable!';
     }
   }
 

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -109,7 +109,7 @@ enum PlayerErrors {
   /// Filter not found
   filterNotFound,
 
-  /// asking for wave and FFT is not enableb
+  /// asking for wave and FFT is not enabled
   visualizationNotEnabled;
 
   /// Returns a human-friendly sentence describing the error.

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -146,7 +146,7 @@ interface class SoLoud {
   bool _isInitialized = false;
 
   /// Whether or not is it possible to ask for wave and FFT data.
-  bool isVisualizationEnabled = false;
+  bool _isVisualizationEnabled = false;
 
   /// The current status of the engine. This is `true` when the engine
   /// has been initialized and is immediately ready.
@@ -368,7 +368,7 @@ interface class SoLoud {
             /// get the visualization flag from the player on C side.
             /// Eventually we can set this as a parameter during the
             /// initialization with some other parameters like `sampleRate`
-            isVisualizationEnabled = getVisualizationEnabled().isEnabled;
+            _isVisualizationEnabled = getVisualizationEnabled().isEnabled;
           } else {
             _log.severe('_initEngine() failed with error: $value');
             _cleanUpUnsuccessfulInitialization();
@@ -1081,7 +1081,7 @@ interface class SoLoud {
       return PlayerErrors.engineNotInited;
     }
     SoLoudController().soLoudFFI.setVisualizationEnabled(enabled);
-    isVisualizationEnabled = enabled;
+    _isVisualizationEnabled = enabled;
     return PlayerErrors.noError;
   }
 
@@ -1235,7 +1235,7 @@ interface class SoLoud {
       _log.severe(() => 'getAudioTexture2D(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
     }
-    if (!isVisualizationEnabled) {
+    if (!_isVisualizationEnabled) {
       return PlayerErrors.visualizationNotEnabled;
     }
     final ret = SoLoudController().soLoudFFI.getAudioTexture2D(audioData);

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -334,6 +334,16 @@ extern "C"
         player.setVisualizationEnabled(enabled);
     }
 
+    /// Get visualization state
+    ///
+    /// Return true if enabled
+    FFI_PLUGIN_EXPORT int getVisualizationEnabled()
+    {
+        if (!player.isInited())
+            return 0;
+        return player.isVisualizationEnabled();
+    }
+
     /// Returns valid data only if VisualizationEnabled is true
     ///
     /// [fft]

--- a/src/ffi_gen_tmp.h
+++ b/src/ffi_gen_tmp.h
@@ -25,7 +25,7 @@ struct CaptureDevice
 
 
 
-FFI_PLUGIN_EXPORT float getFxParams(enum FilterType filterType, int attributeId);
-
-
-
+/// Get visualization state
+///
+/// Return true if enabled
+FFI_PLUGIN_EXPORT int getVisualizationEnabled();


### PR DESCRIPTION
## Description

Testing  the player with the example app, I got errors while passing from a page that needed audio data for the visualization, to another that it doesn't. The example crashed.

A new function has been implemented to get that flag state of the visualization:
`SoLoud.instance.getVisualizationEnabled()` which returns true or false.
This result is checked when asking for audio data and resolve the issue.
Also added a new PlayerErrors: `visualizationNotEnabled`
which is returned by `SoLoud.instance.getAudioTexture2D` in the case is not yet possible to get audio data.

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
