### PR TITLE
Improve static safety around sound handles and sound hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@
   re-initializing it. Same for `SoLoud.shutdown()`, which will 
   wait for the engine to initialize before shutting it down,
   to avoid various race conditions.
+- Sound handles and sound hashes are now typed: `SoundHandle` and `SoundHash`
+  instead of raw integers.
+  This prevents from erroneously passing a sound handle as a sound hash,
+  for example. This is a breaking API change but, in practice, shouldn't
+  be much of a problem, since these objects were always meant as
+  identifiers (to be taken from some API calls and put into others).
+- `SoundProps.handle` renamed to `SoundProps.handles` (because it's a Set)
+  and also disallowed modifying it from outside the package.
+- All fields of `SoundProps` marked `final`. This is a breaking change
+  but unlikely to have effect (as most users hopefully don't assign
+  to these fields).
 
 #### 1.2.5 (2 Mar 2024)
 - updated mp3, flac and wav decoders

--- a/example/lib/main_wav_stream.dart
+++ b/example/lib/main_wav_stream.dart
@@ -94,8 +94,8 @@ class _MyHomePageState extends State<MyHomePage> {
     if (context.mounted) setState(() {});
 
     timer = Timer.periodic(const Duration(milliseconds: 100), (timer) {
-      if (sounds.isEmpty || sounds[0].handle.isEmpty) return;
-      final p = SoLoud.instance.getPosition(sounds[0].handle.first).position;
+      if (sounds.isEmpty || sounds[0].handles.isEmpty) return;
+      final p = SoLoud.instance.getPosition(sounds[0].handles.first).position;
       if (p <= minLength) seekPos.value = p;
     });
   }
@@ -145,8 +145,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   onChanged: (value) {
                     seekPos.value = value;
                     for (final s in sounds) {
-                      if (s.handle.isEmpty) continue;
-                      SoLoud.instance.seek(s.handle.first, value);
+                      if (s.handles.isEmpty) continue;
+                      SoLoud.instance.seek(s.handles.first, value);
                     }
                   },
                 );
@@ -180,9 +180,9 @@ class _SoundRowState extends State<SoundRow> {
     super.initState();
     max = SoLoud.instance.getLength(widget.soundProps).length;
     timer = Timer.periodic(const Duration(milliseconds: 100), (timer) {
-      if (widget.soundProps.handle.isEmpty) return;
+      if (widget.soundProps.handles.isEmpty) return;
       pos =
-          SoLoud.instance.getPosition(widget.soundProps.handle.first).position;
+          SoLoud.instance.getPosition(widget.soundProps.handles.first).position;
       if (context.mounted) setState(() {});
     });
   }

--- a/example/lib/page_3d_audio.dart
+++ b/example/lib/page_3d_audio.dart
@@ -213,7 +213,7 @@ class _Audio3DWidgetState extends State<Audio3DWidget>
         -100 * delta.dy / (timeStamp.inMilliseconds - precTime.inMilliseconds);
     if (widget.sound != null) {
       SoLoud.instance.set3dSourceParameters(
-        widget.sound!.handle.first,
+        widget.sound!.handles.first,
         posX,
         posY,
         posZ,

--- a/example/lib/page_multi_track.dart
+++ b/example/lib/page_multi_track.dart
@@ -76,8 +76,8 @@ class _PlaySoundWidgetState extends State<PlaySoundWidget> {
   static final Logger _log = Logger('_PlaySoundWidgetState');
 
   late double soundLength;
-  final Map<int, ValueNotifier<bool>> isPaused = {};
-  final Map<int, ValueNotifier<double>> soundPosition = {};
+  final Map<SoundHandle, ValueNotifier<bool>> isPaused = {};
+  final Map<SoundHandle, ValueNotifier<double>> soundPosition = {};
   StreamSubscription<StreamSoundEvent>? _subscription;
   SoundProps? sound;
 
@@ -195,7 +195,7 @@ class PlayingRow extends StatefulWidget {
   });
 
   final double soundLength;
-  final int handle;
+  final SoundHandle handle;
   final VoidCallback onStopped;
 
   @override

--- a/example/lib/page_multi_track.dart
+++ b/example/lib/page_multi_track.dart
@@ -137,9 +137,9 @@ class _PlaySoundWidgetState extends State<PlaySoundWidget> {
           child: Text('load\n${widget.text}'),
         ),
         if (sound != null)
-          for (int i = 0; i < sound!.handle.length; ++i)
+          for (int i = 0; i < sound!.handles.length; ++i)
             PlayingRow(
-              handle: sound!.handle.elementAt(i),
+              handle: sound!.handles.elementAt(i),
               soundLength: soundLength,
               onStopped: () {
                 if (mounted) setState(() {});

--- a/example/lib/page_visualizer.dart
+++ b/example/lib/page_visualizer.dart
@@ -290,7 +290,7 @@ class _PageVisualizerState extends State<PageVisualizer> {
                               if (currentSound == null) return;
                               stopTimer();
                               SoLoud.instance
-                                  .seek(currentSound!.handle.last, value);
+                                  .seek(currentSound!.handles.last, value);
                               soundPosition.value = value;
                               startTimer();
                             },
@@ -519,7 +519,7 @@ class _PageVisualizerState extends State<PageVisualizer> {
     timer = Timer.periodic(const Duration(seconds: 1), (_) {
       if (currentSound != null) {
         soundPosition.value =
-            SoLoud.instance.getPosition(currentSound!.handle.last).position;
+            SoLoud.instance.getPosition(currentSound!.handles.last).position;
       }
     });
   }

--- a/example/lib/waveform/keyboard_widget.dart
+++ b/example/lib/waveform/keyboard_widget.dart
@@ -99,7 +99,7 @@ class _KeyboardWidgetState extends State<KeyboardWidget> {
   Future<void> play(int index) async {
     if (index < 0 || index >= notesKeys.length) return;
     if (isPressed[index].value) return;
-    final handle = widget.notes[index].handle.first;
+    final handle = widget.notes[index].handles.first;
     SoLoud.instance.setRelativePlaySpeed(handle, 0);
     SoLoud.instance.setVolume(handle, 0);
     SoLoud.instance.fadeVolume(handle, 1, widget.fadeIn);
@@ -124,7 +124,7 @@ class _KeyboardWidgetState extends State<KeyboardWidget> {
 
   void stop(int index) {
     if (index < 0 || index >= notesKeys.length) return;
-    for (final h in widget.notes[index].handle) {
+    for (final h in widget.notes[index].handles) {
       SoLoud.instance.fadeVolume(h, 0, widget.fadeOut);
       SoLoud.instance.fadeRelativePlaySpeed(h, 0, widget.fadeSpeedOut);
       SoLoud.instance.schedulePause(h, widget.fadeOut);

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -98,23 +98,23 @@ Future<void> test3() async {
     final d = (sin(i / 6.28) * 400).toInt();
     await SoLoud.instance.play(notes[7]);
     await delay(500 - d);
-    await SoLoud.instance.stop(notes[7].handle.first);
+    await SoLoud.instance.stop(notes[7].handles.first);
 
     await SoLoud.instance.play(notes[10]);
     await delay(550 - d);
-    await SoLoud.instance.stop(notes[10].handle.first);
+    await SoLoud.instance.stop(notes[10].handles.first);
 
     await SoLoud.instance.play(notes[7]);
     await delay(500 - d);
-    await SoLoud.instance.stop(notes[7].handle.first);
+    await SoLoud.instance.stop(notes[7].handles.first);
 
     await SoLoud.instance.play(notes[0]);
     await delay(500 - d);
-    await SoLoud.instance.stop(notes[0].handle.first);
+    await SoLoud.instance.stop(notes[0].handles.first);
 
     await SoLoud.instance.play(notes[4]);
     await delay(800 - d);
-    await SoLoud.instance.stop(notes[4].handle.first);
+    await SoLoud.instance.stop(notes[4].handles.first);
 
     await delay(300);
   }
@@ -141,24 +141,24 @@ Future<void> test2() async {
       'pauseSwitch() failed!',
     );
     await delay(1000);
-    var ret2 = SoLoud.instance.pauseSwitch(currentSound!.handle.first);
+    var ret2 = SoLoud.instance.pauseSwitch(currentSound!.handles.first);
     assert(
       ret2 == PlayerErrors.noError,
       'pauseSwitch() failed!',
     );
-    final ret3 = SoLoud.instance.getPause(currentSound!.handle.first);
+    final ret3 = SoLoud.instance.getPause(currentSound!.handles.first);
     assert(
       ret3.error == PlayerErrors.noError && ret3.pause,
       'play() failed!',
     );
 
     /// seek
-    ret2 = SoLoud.instance.seek(currentSound!.handle.first, 2);
+    ret2 = SoLoud.instance.seek(currentSound!.handles.first, 2);
     assert(
       ret2 == PlayerErrors.noError,
       'seek() failed!',
     );
-    final ret4 = SoLoud.instance.getPosition(currentSound!.handle.first);
+    final ret4 = SoLoud.instance.getPosition(currentSound!.handles.first);
     assert(
       ret4.error == PlayerErrors.noError && ret4.position == 2,
       'getPosition() failed!',
@@ -183,7 +183,7 @@ Future<void> test1() async {
     assert(
       ret.error == PlayerErrors.noError &&
           currentSound!.soundHash.isValid &&
-          currentSound!.handle.length == 1,
+          currentSound!.handles.length == 1,
       'play() failed!',
     );
 
@@ -204,7 +204,7 @@ Future<void> test1() async {
     await SoLoud.instance.play(currentSound!);
     await SoLoud.instance.play(currentSound!);
     assert(
-      currentSound!.handle.length == 4,
+      currentSound!.handles.length == 4,
       'loadFromAssets() failed!',
     );
 
@@ -213,7 +213,7 @@ Future<void> test1() async {
     /// 3798ms explosion.mp3 sample duration
     await delay(4500);
     assert(
-      currentSound!.handle.isEmpty,
+      currentSound!.handles.isEmpty,
       'Play 4 sample handles failed!',
     );
   }

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -182,7 +182,7 @@ Future<void> test1() async {
     final ret = await SoLoud.instance.play(currentSound!);
     assert(
       ret.error == PlayerErrors.noError &&
-          currentSound!.soundHash > 0 &&
+          currentSound!.soundHash.isValid &&
           currentSound!.handle.length == 1,
       'play() failed!',
     );

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -9,6 +9,17 @@
 version: 1
 
 transforms:
+  # SoundProps.handle => SoundProps.handles
+  - title: "Rename to 'handles'"
+    date: 2024-03-11
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      getter: 'handle'
+      inClass: 'SoundProps'
+    changes:
+      - kind: 'rename'
+        newName: 'handles'
+
   # PlayerErrors.isolateAlreadyStarted => SoLoudCapture.multipleInitialization
   - title: "Rename to 'multipleInitialization'"
     date: 2024-03-09

--- a/lib/flutter_soloud.dart
+++ b/lib/flutter_soloud.dart
@@ -6,4 +6,6 @@ export 'src/enums.dart';
 export 'src/filter_params.dart';
 export 'src/soloud.dart';
 export 'src/soloud_capture.dart';
+export 'src/sound_handle.dart';
+export 'src/sound_hash.dart';
 export 'src/tools/soloud_tools.dart';

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -1,13 +1,19 @@
 // ignore_for_file: require_trailing_commas, avoid_positional_boolean_parameters
 
 import 'dart:async';
+import 'dart:collection';
 import 'dart:ffi' as ffi;
 import 'dart:isolate';
 
-import 'package:flutter_soloud/flutter_soloud.dart';
 import 'package:flutter_soloud/src/audio_isolate.dart';
+import 'package:flutter_soloud/src/enums.dart';
+import 'package:flutter_soloud/src/filter_params.dart';
+import 'package:flutter_soloud/src/soloud_capture.dart';
 import 'package:flutter_soloud/src/soloud_controller.dart';
+import 'package:flutter_soloud/src/sound_handle.dart';
+import 'package:flutter_soloud/src/sound_hash.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 
 /// sound event types
 enum SoundEvent {
@@ -19,30 +25,55 @@ enum SoundEvent {
 }
 
 /// the type sent back to the user when a sound event occurs
-typedef StreamSoundEvent = ({SoundEvent event, SoundProps sound, int handle});
+typedef StreamSoundEvent = ({
+  SoundEvent event,
+  SoundProps sound,
+  SoundHandle handle,
+});
 
 /// the sound class
 class SoundProps {
   ///
   SoundProps(this.soundHash);
 
-  /// the [hash] returned by [loadFile()]
-  final int soundHash;
+  /// The hash uniquely identifying this loaded sound.
+  final SoundHash soundHash;
 
-  /// handles of this sound. Multiple instances of this sound can be
-  /// played, each with their unique handle
-  Set<int> handle = {};
+  /// This getter is [deprecated] and will be removed. Use [handles] instead.
+  @Deprecated("Use 'handles' instead")
+  UnmodifiableSetView<SoundHandle> get handle => handles;
+
+  /// The handles of currently playing instances of this sound.
+  ///
+  /// A sound (expressed as [SoundProps]) can be loaded once, but then
+  /// played multiple times. It's even possible to play several instances
+  /// of the sound simultaneously.
+  ///
+  /// Each time you [SoLoud.play] a sound, you get back a [SoundHandle],
+  /// and that same handle will be added to this [handles] set.
+  /// When the sound finishes playing, its handle will be removed from this set.
+  ///
+  /// This set is unmodifiable.
+  late final UnmodifiableSetView<SoundHandle> handles =
+      UnmodifiableSetView(handlesInternal);
+
+  /// The [internal] backing of [handles].
+  ///
+  /// Use [handles].
+  @internal
+  final Set<SoundHandle> handlesInternal = {};
 
   ///
   // TODO(me): make marker keys time able to trigger an event
-  List<double> keys = [];
+  final List<double> keys = [];
 
   /// the user can listen ie when a sound ends or key events (TODO)
-  StreamController<StreamSoundEvent> soundEvents = StreamController.broadcast();
+  final StreamController<StreamSoundEvent> soundEvents =
+      StreamController.broadcast();
 
   @override
   String toString() {
-    return 'soundHash: $soundHash has ${handle.length} active handles';
+    return 'soundHash: $soundHash has ${handles.length} active handles';
   }
 }
 
@@ -384,7 +415,7 @@ interface class SoLoud {
             orElse: () {
               _log.info(() => 'Received an event for sound with handle: '
                   "${data.handle} but such sound isn't among activeSounds.");
-              return SoundProps(0);
+              return SoundProps(SoundHash.invalid());
             },
           );
 
@@ -398,9 +429,9 @@ interface class SoLoud {
           /// send the handle event to the listeners and remove it
           if (data.event == SoundEvent.handleIsNoMoreValid) {
             /// ...put in its own stream the event, then remove the handle
-            if (sound.soundHash != 0) {
+            if (sound.soundHash.isValid) {
               sound.soundEvents.add(data);
-              sound.handle.removeWhere(
+              sound.handlesInternal.removeWhere(
                 (handle) {
                   return handle == data.handle;
                 },
@@ -808,7 +839,10 @@ interface class SoLoud {
   ) async {
     if (!isInitialized) {
       _log.severe(() => 'speechText(): ${PlayerErrors.engineNotInited}');
-      return (error: PlayerErrors.engineNotInited, sound: SoundProps(-1));
+      return (
+        error: PlayerErrors.engineNotInited,
+        sound: SoundProps(SoundHash.invalid()),
+      );
     }
     _mainToIsolateStream?.send(
       {
@@ -836,7 +870,7 @@ interface class SoLoud {
   /// Returns PlayerErrors.noError if success, the new sound and
   /// the new handle newHandle
   ///
-  Future<({PlayerErrors error, SoundProps sound, int newHandle})> play(
+  Future<({PlayerErrors error, SoundProps sound, SoundHandle newHandle})> play(
     SoundProps sound, {
     double volume = 1,
     double pan = 0,
@@ -844,7 +878,11 @@ interface class SoLoud {
   }) async {
     if (!isInitialized) {
       _log.severe(() => 'play(): ${PlayerErrors.engineNotInited}');
-      return (error: PlayerErrors.engineNotInited, sound: sound, newHandle: 0);
+      return (
+        error: PlayerErrors.engineNotInited,
+        sound: sound,
+        newHandle: SoundHandle.error(),
+      );
     }
     _mainToIsolateStream?.send(
       {
@@ -860,25 +898,29 @@ interface class SoLoud {
     final ret = (await _waitForEvent(
       MessageEvents.play,
       (soundHash: sound.soundHash, volume: volume, pan: pan, paused: paused),
-    )) as ({PlayerErrors error, int newHandle});
+    )) as ({PlayerErrors error, SoundHandle newHandle});
     _logPlayerError(ret.error, from: 'play()');
     if (ret.error != PlayerErrors.noError) {
-      return (error: ret.error, sound: sound, newHandle: 0);
+      return (
+        error: ret.error,
+        sound: sound,
+        newHandle: SoundHandle.error(),
+      );
     }
 
     try {
       /// add the new handle to the sound
       activeSounds
           .firstWhere((s) => s.soundHash == sound.soundHash)
-          .handle
+          .handlesInternal
           .add(ret.newHandle);
-      sound.handle.add(ret.newHandle);
+      sound.handlesInternal.add(ret.newHandle);
     } catch (e) {
       _log.severe('play(): soundHash ${sound.soundHash} not found', e);
       return (
         error: PlayerErrors.soundHashNotFound,
         sound: sound,
-        newHandle: 0
+        newHandle: SoundHandle.error(),
       );
     }
     return (
@@ -893,7 +935,7 @@ interface class SoLoud {
   /// [handle] the sound handle
   /// Returns [PlayerErrors.noError] if success
   ///
-  PlayerErrors pauseSwitch(int handle) {
+  PlayerErrors pauseSwitch(SoundHandle handle) {
     if (!isInitialized) {
       _log.severe(() => 'pauseSwitch(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -907,7 +949,7 @@ interface class SoLoud {
   /// [handle] the sound handle
   /// Returns [PlayerErrors.noError] if success
   ///
-  PlayerErrors setPause(int handle, bool pause) {
+  PlayerErrors setPause(SoundHandle handle, bool pause) {
     if (!isInitialized) {
       _log.severe(() => 'setPause(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -921,7 +963,7 @@ interface class SoLoud {
   /// [handle] the sound handle
   /// Return [PlayerErrors.noError] on success and true if paused
   ///
-  ({PlayerErrors error, bool pause}) getPause(int handle) {
+  ({PlayerErrors error, bool pause}) getPause(SoundHandle handle) {
     if (!isInitialized) {
       _log.severe(() => 'getPause(): ${PlayerErrors.engineNotInited}');
       return (error: PlayerErrors.engineNotInited, pause: false);
@@ -942,7 +984,7 @@ interface class SoLoud {
   ///
   /// [handle] the sound handle
   /// [speed] the new speed
-  PlayerErrors setRelativePlaySpeed(int handle, double speed) {
+  PlayerErrors setRelativePlaySpeed(SoundHandle handle, double speed) {
     if (!isInitialized) {
       _log.severe(
           () => 'setRelativePlaySpeed(): ${PlayerErrors.engineNotInited}');
@@ -955,7 +997,8 @@ interface class SoLoud {
   /// Return the current play speed.
   ///
   /// [handle] the sound handle
-  ({PlayerErrors error, double speed}) getRelativePlaySpeed(int handle) {
+  ({PlayerErrors error, double speed}) getRelativePlaySpeed(
+      SoundHandle handle) {
     if (!isInitialized) {
       _log.severe(
           () => 'getRelativePlaySpeed(): ${PlayerErrors.engineNotInited}');
@@ -971,7 +1014,7 @@ interface class SoLoud {
   /// [handle] the sound handle to stop
   /// Return [PlayerErrors.noError] on success
   ///
-  Future<PlayerErrors> stop(int handle) async {
+  Future<PlayerErrors> stop(SoundHandle handle) async {
     if (!isInitialized) {
       _log.severe(() => 'stop(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -986,7 +1029,7 @@ interface class SoLoud {
 
     /// find a sound with this handle and remove that handle from the list
     for (final sound in activeSounds) {
-      sound.handle.removeWhere((element) => element == handle);
+      sound.handlesInternal.removeWhere((element) => element == handle);
     }
     return PlayerErrors.noError;
   }
@@ -1052,7 +1095,7 @@ interface class SoLoud {
   /// [enable]
   /// Return [PlayerErrors.noError] on success
   ///
-  PlayerErrors setLooping(int handle, bool enable) {
+  PlayerErrors setLooping(SoundHandle handle, bool enable) {
     if (!isInitialized) {
       _log.severe(() => 'setLooping(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1107,7 +1150,7 @@ interface class SoLoud {
   /// If you need to seek MP3s without lags, please, use
   /// `mode`=`LoadMode.memory` instead or other supported audio formats!
   ///
-  PlayerErrors seek(int handle, double time) {
+  PlayerErrors seek(SoundHandle handle, double time) {
     if (!isInitialized) {
       _log.severe(() => 'seek(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1121,7 +1164,7 @@ interface class SoLoud {
   /// [handle] the sound handle
   /// Return PlayerErrors.noError if success and position in seconds
   ///
-  ({PlayerErrors error, double position}) getPosition(int handle) {
+  ({PlayerErrors error, double position}) getPosition(SoundHandle handle) {
     if (!isInitialized) {
       _log.severe(() => 'getPosition(): ${PlayerErrors.engineNotInited}');
       return (error: PlayerErrors.engineNotInited, position: 0.0);
@@ -1160,7 +1203,7 @@ interface class SoLoud {
   ///
   /// Return PlayerErrors.noError if success and volume
   ///
-  ({PlayerErrors error, double volume}) getVolume(int handle) {
+  ({PlayerErrors error, double volume}) getVolume(SoundHandle handle) {
     if (!isInitialized) {
       _log.severe(() => 'getVolume(): ${PlayerErrors.engineNotInited}');
       return (error: PlayerErrors.engineNotInited, volume: 0.0);
@@ -1173,7 +1216,7 @@ interface class SoLoud {
   ///
   /// Return PlayerErrors.noError if success
   ///
-  PlayerErrors setVolume(int handle, double volume) {
+  PlayerErrors setVolume(SoundHandle handle, double volume) {
     if (!isInitialized) {
       _log.severe(() => 'setVolume(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1187,7 +1230,8 @@ interface class SoLoud {
   /// [handle] handle to check
   /// Return PlayerErrors.noError if success and isvalid==true if valid
   ///
-  ({PlayerErrors error, bool isValid}) getIsValidVoiceHandle(int handle) {
+  ({PlayerErrors error, bool isValid}) getIsValidVoiceHandle(
+      SoundHandle handle) {
     if (!isInitialized) {
       _log.severe(
           () => 'getIsValidVoiceHandle(): ${PlayerErrors.engineNotInited}');
@@ -1261,7 +1305,7 @@ interface class SoLoud {
 
   /// Smoothly change a channel's volume over specified time.
   ///
-  PlayerErrors fadeVolume(int handle, double to, double time) {
+  PlayerErrors fadeVolume(SoundHandle handle, double to, double time) {
     if (!isInitialized) {
       _log.severe(() => 'fadeVolume(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1272,7 +1316,7 @@ interface class SoLoud {
 
   /// Smoothly change a channel's pan setting over specified time.
   ///
-  PlayerErrors fadePan(int handle, double to, double time) {
+  PlayerErrors fadePan(SoundHandle handle, double to, double time) {
     if (!isInitialized) {
       _log.severe(() => 'fadePan(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1283,7 +1327,8 @@ interface class SoLoud {
 
   /// Smoothly change a channel's relative play speed over specified time.
   ///
-  PlayerErrors fadeRelativePlaySpeed(int handle, double to, double time) {
+  PlayerErrors fadeRelativePlaySpeed(
+      SoundHandle handle, double to, double time) {
     if (!isInitialized) {
       _log.severe(
           () => 'fadeRelativePlaySpeed(): ${PlayerErrors.engineNotInited}');
@@ -1296,7 +1341,7 @@ interface class SoLoud {
 
   /// After specified time, pause the channel.
   ///
-  PlayerErrors schedulePause(int handle, double time) {
+  PlayerErrors schedulePause(SoundHandle handle, double time) {
     if (!isInitialized) {
       _log.severe(() => 'schedulePause(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1307,7 +1352,7 @@ interface class SoLoud {
 
   /// After specified time, stop the channel.
   ///
-  PlayerErrors scheduleStop(int handle, double time) {
+  PlayerErrors scheduleStop(SoundHandle handle, double time) {
     if (!isInitialized) {
       _log.severe(() => 'scheduleStop(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1319,7 +1364,7 @@ interface class SoLoud {
   /// Set fader to oscillate the volume at specified frequency.
   ///
   PlayerErrors oscillateVolume(
-      int handle, double from, double to, double time) {
+      SoundHandle handle, double from, double to, double time) {
     if (!isInitialized) {
       _log.severe(() => 'oscillateVolume(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1331,7 +1376,8 @@ interface class SoLoud {
 
   /// Set fader to oscillate the panning at specified frequency.
   ///
-  PlayerErrors oscillatePan(int handle, double from, double to, double time) {
+  PlayerErrors oscillatePan(
+      SoundHandle handle, double from, double to, double time) {
     if (!isInitialized) {
       _log.severe(() => 'oscillatePan(): ${PlayerErrors.engineNotInited}');
       return PlayerErrors.engineNotInited;
@@ -1344,7 +1390,7 @@ interface class SoLoud {
   /// Set fader to oscillate the relative play speed at specified frequency.
   ///
   PlayerErrors oscillateRelativePlaySpeed(
-      int handle, double from, double to, double time) {
+      SoundHandle handle, double from, double to, double time) {
     if (!isInitialized) {
       _log.severe('oscillateRelativePlaySpeed(): '
           '${PlayerErrors.engineNotInited}');
@@ -1549,7 +1595,8 @@ interface class SoLoud {
   ///
   /// Returns the handle of the sound, 0 if error.
   ///
-  Future<({PlayerErrors error, SoundProps sound, int newHandle})> play3d(
+  Future<({PlayerErrors error, SoundProps sound, SoundHandle newHandle})>
+      play3d(
     SoundProps sound,
     double posX,
     double posY,
@@ -1562,7 +1609,11 @@ interface class SoLoud {
   }) async {
     if (!isInitialized) {
       _log.severe(() => 'play3d(): ${PlayerErrors.engineNotInited}');
-      return (error: PlayerErrors.engineNotInited, sound: sound, newHandle: 0);
+      return (
+        error: PlayerErrors.engineNotInited,
+        sound: sound,
+        newHandle: SoundHandle.error(),
+      );
     }
     _mainToIsolateStream?.send(
       {
@@ -1593,22 +1644,22 @@ interface class SoLoud {
         volume: volume,
         paused: paused
       ),
-    )) as ({PlayerErrors error, int newHandle});
+    )) as ({PlayerErrors error, SoundHandle newHandle});
     _logPlayerError(ret.error, from: 'play3d() result');
     try {
       /// add the new handle to the sound
       activeSounds
           .firstWhere((s) => s.soundHash == sound.soundHash)
-          .handle
+          .handlesInternal
           .add(ret.newHandle);
-      sound.handle.add(ret.newHandle);
+      sound.handlesInternal.add(ret.newHandle);
     } catch (e, s) {
       _log.severe(
           () => 'play3d(): soundHash ${sound.soundHash} not found', e, s);
       return (
         error: PlayerErrors.soundHashNotFound,
         sound: sound,
-        newHandle: 0
+        newHandle: SoundHandle.error(),
       );
     }
     return (
@@ -1684,22 +1735,23 @@ interface class SoLoud {
   /// You can set the position and velocity parameters of a live
   /// 3d audio source with one call.
   ///
-  void set3dSourceParameters(int handle, double posX, double posY, double posZ,
-      double velocityX, double velocityY, double velocityZ) {
+  void set3dSourceParameters(SoundHandle handle, double posX, double posY,
+      double posZ, double velocityX, double velocityY, double velocityZ) {
     SoLoudController().soLoudFFI.set3dSourceParameters(
         handle, posX, posY, posZ, velocityX, velocityY, velocityZ);
   }
 
   /// You can set the position parameters of a live 3d audio source.
   ///
-  void set3dSourcePosition(int handle, double posX, double posY, double posZ) {
+  void set3dSourcePosition(
+      SoundHandle handle, double posX, double posY, double posZ) {
     SoLoudController().soLoudFFI.set3dSourcePosition(handle, posX, posY, posZ);
   }
 
   /// You can set the velocity parameters of a live 3d audio source.
   ///
-  void set3dSourceVelocity(
-      int handle, double velocityX, double velocityY, double velocityZ) {
+  void set3dSourceVelocity(SoundHandle handle, double velocityX,
+      double velocityY, double velocityZ) {
     SoLoudController()
         .soLoudFFI
         .set3dSourceVelocity(handle, velocityX, velocityY, velocityZ);
@@ -1709,7 +1761,7 @@ interface class SoLoud {
   /// of a live 3d audio source.
   ///
   void set3dSourceMinMaxDistance(
-      int handle, double minDistance, double maxDistance) {
+      SoundHandle handle, double minDistance, double maxDistance) {
     SoLoudController()
         .soLoudFFI
         .set3dSourceMinMaxDistance(handle, minDistance, maxDistance);
@@ -1726,7 +1778,7 @@ interface class SoLoud {
   /// see https://solhsa.com/soloud/concepts3d.html
   ///
   void set3dSourceAttenuation(
-    int handle,
+    SoundHandle handle,
     int attenuationModel,
     double attenuationRolloffFactor,
   ) {
@@ -1739,7 +1791,7 @@ interface class SoLoud {
 
   /// You can change the doppler factor of a live 3d audio source.
   ///
-  void set3dSourceDopplerFactor(int handle, double dopplerFactor) {
+  void set3dSourceDopplerFactor(SoundHandle handle, double dopplerFactor) {
     SoLoudController()
         .soLoudFFI
         .set3dSourceDopplerFactor(handle, dopplerFactor);

--- a/lib/src/sound_handle.dart
+++ b/lib/src/sound_handle.dart
@@ -1,0 +1,39 @@
+import 'package:meta/meta.dart';
+
+/// A handle for a sound that is currently playing.
+///
+/// SoLoud's methods, such as `play()`, return the [SoundHandle] of the
+/// newly instanced sound. That handle can then be used in other methods,
+/// such as `stop()` or `seek()`, to affect that particular instance.
+///
+/// On the C++ side, sound handles are just raw integers.
+/// On the Dart side, they are implemented as
+/// an [extension type](https://dart.dev/language/extension-types) around [int]
+/// that makes them statically type safe.
+/// It is not possible, for example, to mistakenly pass a random
+/// integer number as if it was a handle, or a sound hash as if it was
+/// a handle.
+///
+/// Constructors are marked [internal] because it should not be possible
+/// for users to create a handle from Dart.
+extension type SoundHandle._(int id) {
+  /// Constructs a valid handle with [id].
+  @internal
+  SoundHandle(this.id)
+      : assert(
+            id >= 0,
+            'Handle with id<0 is being constructed. '
+            'These are reserved for invalid handles.');
+
+  /// Constructs an invalid handle (for APIs that need to return _some_ handle
+  /// even during errors).
+  @internal
+  SoundHandle.error() : this._(-1);
+
+  /// Checks if the handle represents an error (it was constructed
+  /// with [SoundHandle.error]).
+  ///
+  /// Does _not_ check whether the handle is "valid" (i.e. attached
+  /// to an active sound) or not.
+  bool get isError => id < 0;
+}

--- a/lib/src/sound_hash.dart
+++ b/lib/src/sound_hash.dart
@@ -1,0 +1,54 @@
+import 'dart:math';
+
+import 'package:meta/meta.dart';
+
+/// A hash of a `SoundProps` instance.
+///
+/// Each newly loaded sound gets a unique hash. This hash is then used
+/// to uniquely identify the loaded sound to SoLoud.
+///
+/// On the C++ side, sound hashes are just raw integers.
+/// On the Dart side, they are implemented as
+/// an [extension type](https://dart.dev/language/extension-types) around [int]
+/// that makes them statically type safe.
+/// It is not possible, for example, to mistakenly pass a random
+/// integer number as if it was a sound hash, or a sound _handle_ as if it was
+/// a sound hash.
+///
+/// Constructors are marked [internal] because it should not be possible
+/// for users to create a sound hash from Dart.
+extension type SoundHash._(int hash) {
+  /// Constructs a valid sound hash with [hash].
+  @internal
+  SoundHash(this.hash)
+      : assert(
+          hash > 0,
+          'Trying to create a valid sound hash with the value 0',
+        );
+
+  /// Constructs an invalid sound hash
+  /// (for APIs that need to return _some_ hash even during errors).
+  @internal
+  SoundHash.invalid() : this._(0);
+
+  /// Generate a "fake" [SoundHash] for generated (i.e. non-loaded) sounds.
+  ///
+  /// Sound hashes are normally computed from a file name in the C code.
+  @internal
+  factory SoundHash.random() {
+    // Dart must support 32 bit systems.
+    const largest32BitInt = 1 << 32;
+    // Generate a random integer, but not 0 (which is reserved for invalid
+    // sound hashes).
+    final soundHash = _random.nextInt(largest32BitInt - 1) + 1;
+    return SoundHash(soundHash);
+  }
+
+  /// Checks if the hash was constructed normally (`true`)
+  /// or if it should be considered an error (`false`).
+  bool get isValid => hash != 0;
+
+  /// A random generator used for creating (fake) sound hashes for
+  /// generated (i.e. non-loaded) sounds.
+  static final Random _random = Random();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ screenshots:
     path: img/screenshot.png
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: '>=3.3.0'
 
 dependencies:

--- a/test_fixes/soundprops_handles.dart
+++ b/test_fixes/soundprops_handles.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_soloud/flutter_soloud.dart';
+
+Future<void> main() async {
+  final sound = SoundProps(SoundHash.invalid());
+  print(sound.handle);
+}

--- a/test_fixes/soundprops_handles.dart.expect
+++ b/test_fixes/soundprops_handles.dart.expect
@@ -1,0 +1,6 @@
+import 'package:flutter_soloud/flutter_soloud.dart';
+
+Future<void> main() async {
+  final sound = SoundProps(SoundHash.invalid());
+  print(sound.handles);
+}


### PR DESCRIPTION
## Description

- Sound handles and sound hashes are now typed: `SoundHandle` and `SoundHash`
  instead of raw integers.
  This prevents from erroneously passing a sound handle as a sound hash,
  for example. This is a breaking API change but, in practice, shouldn't
  be much of a problem, since these objects were always meant as
  identifiers (to be taken from some API calls and put into others).
- `SoundProps.handle` renamed to `SoundProps.handles` (because it's a Set)
  and also disallowed modifying it from outside the package.
- All fields of `SoundProps` marked `final`. This is a breaking change
  but unlikely to have effect (as most users hopefully don't assign
  to these fields).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
