### PR TITLE
Fix issue where errors from SoLoud would not propagate

### DIFF
--- a/lib/src/audio_isolate.dart
+++ b/lib/src/audio_isolate.dart
@@ -207,6 +207,19 @@ void audioIsolate(SendPort isolateToMainStream) {
           pan: args.pan,
           paused: args.paused,
         );
+
+        if (ret.isError) {
+          isolateToMainStream.send({
+            'event': event['event'],
+            'args': args,
+            'return': (
+              error: PlayerErrors.unknownError,
+              newHandle: ret,
+            ),
+          });
+          break;
+        }
+
         // add the new handle to the [activeSound] hash list
         try {
           activeSounds
@@ -296,6 +309,19 @@ void audioIsolate(SendPort isolateToMainStream) {
           volume: args.volume,
           paused: args.paused,
         );
+
+        if (ret.isError) {
+          isolateToMainStream.send({
+            'event': event['event'],
+            'args': args,
+            'return': (
+              error: PlayerErrors.unknownError,
+              newHandle: ret,
+            ),
+          });
+          break;
+        }
+
         // add the new handle to the [activeSound] hash list
         try {
           activeSounds

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -375,7 +375,8 @@ class FlutterSoLoudFfi {
   /// [volume] 1.0f full volume
   /// [pan] 0.0f centered
   /// [paused] 0 not pause
-  /// Return the handle of the sound, 0 if error
+  ///
+  /// Return the handle of the sound, [SoundHandle.error] if error
   SoundHandle play(
     SoundHash soundHash, {
     double volume = 1,
@@ -383,6 +384,9 @@ class FlutterSoLoudFfi {
     bool paused = false,
   }) {
     final handleId = _play(soundHash.hash, volume, pan, paused ? 1 : 0);
+    if (handleId == 0) {
+      return SoundHandle.error();
+    }
     return SoundHandle(handleId);
   }
 
@@ -952,7 +956,7 @@ class FlutterSoLoudFfi {
 
   /// play3d() is the 3d version of the play() call.
   ///
-  /// Returns the handle of the sound, 0 if error
+  /// Returns the handle of the sound, [SoundHandle.error] if error
   SoundHandle play3d(
     SoundHash soundHash,
     double posX,
@@ -975,6 +979,9 @@ class FlutterSoLoudFfi {
       volume,
       paused ? 1 : 0,
     );
+    if (handleId == 0) {
+      return SoundHandle.error();
+    }
     return SoundHandle(handleId);
   }
 


### PR DESCRIPTION
## Description

The C++ `play` and `play3d` methods return a 0 when there's an error. I neglected to convert that 
to `SoundHandle.error()`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
