### PR TITLE
adding looping and start loop at position to play() and play3d()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 2.0.0-pre.X
+- added `looping` and `loopingStartAt` properties to `SoLoud.play()` and `SoLoud.play3d()`.
+- added `SoLoud.getLooping()` to retrieve the looping state of a sound.
+- added `SoLoud.getLoopPoint()` and `SoLoud.setLoopPoint()` to get and set the looping start position of a sound.
+
 #### 2.0.0-pre.0 (11 Mar 2024)
 - added `bool SoLoud.getVisualizationEnabled()` to get the current state of the visualization.
 - added `mode` property to `SoLoud.loadFile()` and `SoloudTools.loadFrom*` to prevent to load the whole audio data into memory:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ The `AudioIsolate` instance has the duty of receiving commands and sending them 
 | **getRelativePlaySpeed**| ({PlayerErrors error, double speed})| `int` handle| Return the current play speed.|
 | **stop**| PlayerErrors| `int` handle| Stop an already loaded sound identified by [handle] and clear it.|
 | **disposeSound**| PlayerErrors| `int` handle| Stop ALL handles of the already loaded sound identified by [soundHash] and dispose it.|
+| **getLooping**| ({PlayerErrors error, bool isLooping})| -| Query whether a sound is set to loop.|
 | **setLooping**| -| `int` handle, `bool` enable| This function can be used to set a sample to play on repeat, instead of just playing once.|
+| **getLoopPoint**| ({PlayerErrors error, double time})| -| Get sound loop point value.|
+| **setLoopPoint**| PlayerErrors| `SoundHandle` handle, `double` time| Set sound loop point value.|
 | **getLength**| ({PlayerErrors error, double length})| `int` soundHash| Get the sound length in seconds.|
 | **seek**| PlayerErrors| `int` handle, `double` time| Seek playing in seconds.<br/>WARNING: when loading an MP3 file with `mode = LoadMode.disk`, the seek is laggy. This should not happens with FLACs, OGGs and WAVs.|
 | **getPosition**| ({PlayerErrors error, double position})| `int` handle| Get the current sound position in seconds.|

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_soloud/flutter_soloud.dart';
 import 'package:flutter_soloud_example/controls.dart';
 import 'package:flutter_soloud_example/page_3d_audio.dart';
 import 'package:flutter_soloud_example/page_hello_flutter.dart';
@@ -55,23 +54,19 @@ class MyHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DefaultTabController(
+    return const DefaultTabController(
       length: 5,
-      initialIndex: 4,
+      initialIndex: 2,
       child: SafeArea(
         child: Scaffold(
           body: Column(
             children: [
-              const Controls(),
+              Controls(),
               SingleChildScrollView(
                 scrollDirection: Axis.horizontal,
                 child: TabBar(
-                  onTap: (value) {
-                    debugPrint('ON TAP');
-                    // SoLoud.instance.shutdown();
-                  },
                   isScrollable: true,
-                  tabs: const [
+                  tabs: [
                     Tab(text: 'hello world!'),
                     Tab(text: 'visualizer'),
                     Tab(text: 'multi track'),
@@ -80,8 +75,8 @@ class MyHomePage extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(height: 8),
-              const Expanded(
+              SizedBox(height: 8),
+              Expanded(
                 child: TabBarView(
                   physics: NeverScrollableScrollPhysics(),
                   children: [

--- a/example/lib/page_3d_audio.dart
+++ b/example/lib/page_3d_audio.dart
@@ -103,7 +103,6 @@ class _Page3DAudioState extends State<Page3DAudio> {
     final playRet = await SoLoud.instance.play3d(currentSound!, 0, 0, 0);
     if (playRet.error != PlayerErrors.noError) return;
 
-    SoLoud.instance.setLooping(playRet.newHandle, true);
     currentSound = playRet.sound;
 
     spinAround = true;
@@ -126,10 +125,15 @@ class _Page3DAudioState extends State<Page3DAudio> {
     currentSound = await SoloudTools.loadFromAssets('assets/audio/siren.mp3');
 
     /// play it
-    final playRet = await SoLoud.instance.play3d(currentSound!, 0, 0, 0);
+    final playRet = await SoLoud.instance.play3d(
+      currentSound!,
+      0,
+      0,
+      0,
+      looping: true,
+    );
     if (playRet.error != PlayerErrors.noError) return;
 
-    SoLoud.instance.setLooping(playRet.newHandle, true);
     SoLoud.instance.set3dSourceMinMaxDistance(
       playRet.newHandle,
       50,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.5"
+    version: "2.0.0-pre.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/audio_isolate.dart
+++ b/lib/src/audio_isolate.dart
@@ -212,7 +212,7 @@ void audioIsolate(SendPort isolateToMainStream) {
           activeSounds
               .firstWhere((s) => s.soundHash == args.soundHash)
               .handlesInternal
-              .add(ret);
+              .add(ret.handle);
         } catch (e) {
           debugPrint('No sound with soundHash ${args.soundHash} found!');
           isolateToMainStream.send({

--- a/lib/src/audio_isolate.dart
+++ b/lib/src/audio_isolate.dart
@@ -50,7 +50,9 @@ typedef ArgsPlay = ({
   SoundHash soundHash,
   double volume,
   double pan,
-  bool paused
+  bool paused,
+  bool looping,
+  double loopingStartAt,
 });
 typedef ArgsPlay3d = ({
   SoundHash soundHash,
@@ -61,7 +63,9 @@ typedef ArgsPlay3d = ({
   double velY,
   double velZ,
   double volume,
-  bool paused
+  bool paused,
+  bool looping,
+  double loopingStartAt,
 });
 typedef ArgsStop = ({SoundHandle handle});
 typedef ArgsDisposeSound = ({SoundHash soundHash});
@@ -206,13 +210,28 @@ void audioIsolate(SendPort isolateToMainStream) {
           volume: args.volume,
           pan: args.pan,
           paused: args.paused,
+          looping: args.looping,
+          loopingStartAt: args.loopingStartAt,
         );
+
+        if (ret.error != PlayerErrors.noError) {
+          isolateToMainStream.send({
+            'event': event['event'],
+            'args': args,
+            'return': (
+              error: ret.error,
+              newHandle: SoundHandle.error(),
+            ),
+          });
+          break;
+        }
+
         // add the new handle to the [activeSound] hash list
         try {
           activeSounds
               .firstWhere((s) => s.soundHash == args.soundHash)
               .handlesInternal
-              .add(ret.handle);
+              .add(ret.newHandle);
         } catch (e) {
           debugPrint('No sound with soundHash ${args.soundHash} found!');
           isolateToMainStream.send({
@@ -220,7 +239,7 @@ void audioIsolate(SendPort isolateToMainStream) {
             'args': args,
             'return': (
               error: PlayerErrors.soundHashNotFound,
-              newHandle: SoundHandle.error()
+              newHandle: SoundHandle.error(),
             ),
           });
           break;
@@ -228,7 +247,7 @@ void audioIsolate(SendPort isolateToMainStream) {
         isolateToMainStream.send({
           'event': event['event'],
           'args': args,
-          'return': (error: PlayerErrors.noError, newHandle: ret),
+          'return': (error: PlayerErrors.noError, newHandle: ret.newHandle),
         });
         break;
 
@@ -295,26 +314,44 @@ void audioIsolate(SendPort isolateToMainStream) {
           velZ: args.velZ,
           volume: args.volume,
           paused: args.paused,
+          looping: args.looping,
+          loopingStartAt: args.loopingStartAt,
         );
+
+        if (ret.error != PlayerErrors.noError) {
+          isolateToMainStream.send({
+            'event': event['event'],
+            'args': args,
+            'return': (
+              error: ret.error,
+              newHandle: SoundHandle.error(),
+            ),
+          });
+          break;
+        }
+
         // add the new handle to the [activeSound] hash list
         try {
           activeSounds
               .firstWhere((s) => s.soundHash == args.soundHash)
               .handlesInternal
-              .add(ret);
+              .add(ret.newHandle);
         } catch (e) {
           debugPrint('No sound with soundHash ${args.soundHash} found!');
           isolateToMainStream.send({
             'event': event['event'],
             'args': args,
-            'return': (error: PlayerErrors.soundHashNotFound, newHandle: -1),
+            'return': (
+              error: PlayerErrors.soundHashNotFound,
+              newHandle: SoundHandle.error(),
+            ),
           });
           break;
         }
         isolateToMainStream.send({
           'event': event['event'],
           'args': args,
-          'return': (error: PlayerErrors.noError, newHandle: ret),
+          'return': (error: PlayerErrors.noError, newHandle: ret.newHandle),
         });
         break;
 

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -369,9 +369,9 @@ class FlutterSoLoudFfi {
   late final _getRelativePlaySpeed =
       _getRelativePlaySpeedPtr.asFunction<double Function(int)>();
 
-  /// Play already loaded sound identified by [hash]
+  /// Play already loaded sound identified by [soundHash]
   ///
-  /// [hash] the unique sound hash of a sound
+  /// [soundHash] the unique sound hash of a sound
   /// [volume] 1.0 full volume
   /// [pan] 0.0 centered
   /// [paused] false not paused
@@ -495,8 +495,8 @@ class FlutterSoLoudFfi {
   ///
   /// [handle]
   /// [time] in seconds.
-  void setLoopPoint(int handle, double time) {
-    _setLoopPoint(handle, time);
+  void setLoopPoint(SoundHandle handle, double time) {
+    _setLoopPoint(handle.id, time);
   }
 
   late final _setLoopPointPtr = _lookup<

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -369,33 +369,68 @@ class FlutterSoLoudFfi {
   late final _getRelativePlaySpeed =
       _getRelativePlaySpeedPtr.asFunction<double Function(int)>();
 
-  /// Play already loaded sound identified by [soundHash].
+  /// Play already loaded sound identified by [soundHandle].
   ///
-  /// [soundHash] the unique sound hash of a sound
+  /// [soundHandle] the unique sound hash of a sound
   /// [volume] 1.0f full volume
   /// [pan] 0.0f centered
   /// [paused] 0 not pause
   /// Return the handle of the sound, 0 if error
-  SoundHandle play(
+  // SoundHandle play(
+  //   SoundHash soundHash, {
+  //   double volume = 1,
+  //   double pan = 0,
+  //   bool paused = false,
+  // }) {
+  //   final handleId = _play(soundHash.hash, volume, pan, paused ? 1 : 0);
+  //   return SoundHandle(handleId);
+  // }
+
+  // late final _playPtr = _lookup<
+  //     ffi.NativeFunction<
+  //         ffi.UnsignedInt Function(
+  //           ffi.UnsignedInt,
+  //           ffi.Float,
+  //           ffi.Float,
+  //           ffi.Int,
+  //         )>>('play');
+  // late final _play =
+  //     _playPtr.asFunction<int Function(int, double, double, int)>();
+
+  /// Play already loaded sound identified by [hash]
+  ///
+  /// [hash] the unique sound hash of a sound
+  /// [volume] 1.0f full volume
+  /// [pan] 0.0f centered
+  /// [paused] 0 not paused
+  /// Return the error if any and a new [handle] of this sound
+  ({PlayerErrors error, SoundHandle handle}) play(
     SoundHash soundHash, {
     double volume = 1,
     double pan = 0,
     bool paused = false,
   }) {
-    final handleId = _play(soundHash.hash, volume, pan, paused ? 1 : 0);
-    return SoundHandle(handleId);
+    // ignore: omit_local_variable_types
+    final ffi.Pointer<ffi.UnsignedInt> newHandle = calloc();
+    final e = _play(
+      soundHash.hash,
+      volume,
+      pan,
+      paused ? 1 : 0,
+      newHandle,
+    );
+    final ret =
+        (error: PlayerErrors.values[e], handle: SoundHandle(newHandle.value));
+    calloc.free(newHandle);
+    return ret;
   }
 
   late final _playPtr = _lookup<
       ffi.NativeFunction<
-          ffi.UnsignedInt Function(
-            ffi.UnsignedInt,
-            ffi.Float,
-            ffi.Float,
-            ffi.Int,
-          )>>('play');
-  late final _play =
-      _playPtr.asFunction<int Function(int, double, double, int)>();
+          ffi.Int32 Function(ffi.UnsignedInt, ffi.Float, ffi.Float, ffi.Int,
+              ffi.Pointer<ffi.UnsignedInt>)>>('play');
+  late final _play = _playPtr.asFunction<
+      int Function(int, double, double, int, ffi.Pointer<ffi.UnsignedInt>)>();
 
   /// Stop already loaded sound identified by [handle] and clear it.
   ///

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -46,7 +46,8 @@ enum CaptureErrors {
   String toString() => 'CaptureErrors.$name ($_asSentence)';
 }
 
-/// Possible player errors
+/// Possible player errors.
+/// New values must be enumerated at the bottom
 enum PlayerErrors {
   /// No error
   noError,
@@ -85,6 +86,12 @@ enum PlayerErrors {
   /// Player not initialized
   backendNotInited,
 
+  /// Filter not found
+  filterNotFound,
+
+  /// asking for wave and FFT is not enabled
+  visualizationNotEnabled,
+
   /// Audio isolate already started
   @Deprecated('Use multipleInitialization instead')
   isolateAlreadyStarted,
@@ -104,13 +111,7 @@ enum PlayerErrors {
   engineNotInited,
 
   /// The engine took too long to initialize.
-  engineInitializationTimedOut,
-
-  /// Filter not found
-  filterNotFound,
-
-  /// asking for wave and FFT is not enabled
-  visualizationNotEnabled;
+  engineInitializationTimedOut;
 
   /// Returns a human-friendly sentence describing the error.
   String get _asSentence {

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -883,6 +883,8 @@ interface class SoLoud {
     double volume = 1,
     double pan = 0,
     bool paused = false,
+    bool looping = false,
+    double loopingStartAt = 0,
   }) async {
     if (!isInitialized) {
       _log.severe(() => 'play(): ${PlayerErrors.engineNotInited}');
@@ -899,13 +901,22 @@ interface class SoLoud {
           soundHash: sound.soundHash,
           volume: volume,
           pan: pan,
-          paused: paused
+          paused: paused,
+          looping: looping,
+          loopingStartAt: loopingStartAt,
         ),
       },
     );
     final ret = (await _waitForEvent(
       MessageEvents.play,
-      (soundHash: sound.soundHash, volume: volume, pan: pan, paused: paused),
+      (
+        soundHash: sound.soundHash,
+        volume: volume,
+        pan: pan,
+        paused: paused,
+        looping: looping,
+        loopingStartAt: loopingStartAt,
+      ),
     )) as ({PlayerErrors error, SoundHandle newHandle});
     _logPlayerError(ret.error, from: 'play()');
     if (ret.error != PlayerErrors.noError) {
@@ -1096,6 +1107,20 @@ interface class SoLoud {
     return PlayerErrors.noError;
   }
 
+  /// Query whether a sound is set to loop.
+  ///
+  /// [handle]
+  /// Returns true if flagged for looping.
+  ///
+  ({PlayerErrors error, bool isLooping}) getLooping(SoundHandle handle) {
+    if (!isInitialized) {
+      _log.severe(() => 'getLooping(): ${PlayerErrors.engineNotInited}');
+      return (error: PlayerErrors.engineNotInited, isLooping: false);
+    }
+    final ret = SoLoudController().soLoudFFI.getLooping(handle.id);
+    return (error: PlayerErrors.noError, isLooping: ret);
+  }
+
   /// This function can be used to set a sample to play on repeat,
   /// instead of just playing once
   ///
@@ -1109,6 +1134,35 @@ interface class SoLoud {
       return PlayerErrors.engineNotInited;
     }
     SoLoudController().soLoudFFI.setLooping(handle, enable);
+    return PlayerErrors.noError;
+  }
+
+  /// Get sound loop point value.
+  ///
+  /// [handle]
+  /// Returns the time in seconds.
+  ///
+  ({PlayerErrors error, double time}) getLoopPoint(SoundHandle handle) {
+    if (!isInitialized) {
+      _log.severe('getLoopPoint(): ${PlayerErrors.engineNotInited}');
+      return (error: PlayerErrors.engineNotInited, time: 0.0);
+    }
+    final time = SoLoudController().soLoudFFI.getLoopPoint(handle.id);
+    return (error: PlayerErrors.noError, time: time);
+  }
+
+  /// Set sound loop point value.
+  ///
+  /// [handle]
+  /// [time] in seconds.
+  /// Return [PlayerErrors.noError] on success
+  ///
+  PlayerErrors setLoopPoint(SoundHandle handle, double time) {
+    if (!isInitialized) {
+      _log.severe('setLoopPoint(): ${PlayerErrors.engineNotInited}');
+      return PlayerErrors.engineNotInited;
+    }
+    SoLoudController().soLoudFFI.setLoopPoint(handle.id, time);
     return PlayerErrors.noError;
   }
 
@@ -1618,8 +1672,12 @@ interface class SoLoud {
   // ////////////////////////////////////////////////
 
   /// play3d() is the 3d version of the play() call.
+  /// The listener position is (0, 0, 0).
   ///
-  /// Returns the handle of the sound, 0 if error.
+  /// [posX], [posY], [posZ] are the audio source position coordinates.
+  /// [velX], [velY], [velZ] are the audio source velocity.
+  /// [volume]
+  /// Return the error if any and a new [newHandle] of this sound
   ///
   Future<({PlayerErrors error, SoundProps sound, SoundHandle newHandle})>
       play3d(
@@ -1632,6 +1690,8 @@ interface class SoLoud {
     double velZ = 0,
     double volume = 1,
     bool paused = false,
+    bool looping = false,
+    double loopingStartAt = 0,
   }) async {
     if (!isInitialized) {
       _log.severe(() => 'play3d(): ${PlayerErrors.engineNotInited}');
@@ -1653,7 +1713,9 @@ interface class SoLoud {
           velY: velY,
           velZ: velZ,
           volume: volume,
-          paused: paused
+          paused: paused,
+          looping: looping,
+          loopingStartAt: loopingStartAt,
         ),
       },
     );
@@ -1668,10 +1730,20 @@ interface class SoLoud {
         velY: velY,
         velZ: velZ,
         volume: volume,
-        paused: paused
+        paused: paused,
+        looping: looping,
+        loopingStartAt: loopingStartAt,
       ),
     )) as ({PlayerErrors error, SoundHandle newHandle});
     _logPlayerError(ret.error, from: 'play3d() result');
+    if (ret.error != PlayerErrors.noError) {
+      return (
+        error: ret.error,
+        sound: sound,
+        newHandle: SoundHandle.error(),
+      );
+    }
+
     try {
       /// add the new handle to the sound
       activeSounds

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -265,22 +265,25 @@ extern "C"
         return player.getRelativePlaySpeed(handle);
     }
 
-    /// Play already loaded sound identified by [handle]
+    /// Play already loaded sound identified by [hash]
     ///
     /// [hash] the unique sound hash of a sound
     /// [volume] 1.0f full volume
     /// [pan] 0.0f centered
-    /// [paused] 0 not pause
-    /// Return the handle of the sound, 0 if error
-    FFI_PLUGIN_EXPORT unsigned int play(
+    /// [paused] 0 not paused
+    /// [newHandle] pointer to the handle for this new sound
+    /// Return the error if any and a new [handle] of this sound
+    FFI_PLUGIN_EXPORT enum PlayerErrors play(
         unsigned int hash,
         float volume,
         float pan,
-        bool paused)
+        bool paused,
+        unsigned int *handle)
     {
         if (!player.isInited())
-            return -1;
-        return player.play(hash, volume, pan, paused);
+            return backendNotInited;
+        *handle = player.play(hash, volume, pan, paused);
+        return *handle == 0 ? soundHashNotFound : noError;
     }
 
     /// Stop already loaded sound identified by [handle] and clear it

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -272,17 +272,24 @@ extern "C"
     /// [pan] 0.0f centered
     /// [paused] 0 not paused
     /// [newHandle] pointer to the handle for this new sound
+    /// [looping] whether to start the sound in looping state.
+    /// [loopingStartAt] If looping is enabled, the loop point is, by default, 
+    /// the start of the stream. The loop start point can be set with this parameter, and 
+    /// current loop point can be queried with [getLoopingPoint] and 
+    /// changed by [setLoopingPoint].
     /// Return the error if any and a new [handle] of this sound
     FFI_PLUGIN_EXPORT enum PlayerErrors play(
-        unsigned int hash,
+        unsigned int soundHash,
         float volume,
         float pan,
         bool paused,
+        bool looping,
+        double loopingStartAt,
         unsigned int *handle)
     {
         if (!player.isInited())
             return backendNotInited;
-        *handle = player.play(hash, volume, pan, paused);
+        *handle = player.play(soundHash, volume, pan, paused, looping, loopingStartAt);
         return *handle == 0 ? soundHashNotFound : noError;
     }
 
@@ -315,6 +322,17 @@ extern "C"
         player.disposeAllSound();
     }
 
+    /// Query whether a sound is set to loop.
+    ///
+    /// [handle]
+    /// Returns true if flagged for looping.
+    FFI_PLUGIN_EXPORT int getLooping(unsigned int handle)
+    {
+        if (!player.isInited())
+            return 0;
+        return player.getLooping(handle) == 1;
+    }
+
     /// This function can be used to set a sample to play on repeat,
     /// instead of just playing once
     ///
@@ -325,6 +343,28 @@ extern "C"
         if (!player.isInited())
             return;
         player.setLooping(handle, enable);
+    }
+
+    /// Get sound loop point value.
+    ///
+    /// [handle]
+    /// Returns the time in seconds.
+    FFI_PLUGIN_EXPORT double getLoopPoint(unsigned int handle)
+    {
+        if (!player.isInited())
+            return 0;
+        return player.getLoopPoint(handle);
+    }
+
+    /// Set sound loop point value.
+    ///
+    /// [handle]
+    /// [time] in seconds.
+    FFI_PLUGIN_EXPORT void setLoopPoint(unsigned int handle, double time)
+    {
+        if (!player.isInited())
+            return;
+        player.setLoopPoint(handle, time);
     }
 
     /// Enable or disable visualization
@@ -727,6 +767,13 @@ extern "C"
 
     /// play3d() is the 3d version of the play() call
     ///
+    /// [posX], [posY], [posZ] are the audio source position coordinates.
+    /// [velX], [velY], [velZ] are the audio source velocity.
+    /// [looping] whether to start the sound in looping state.
+    /// [loopingStartAt] If looping is enabled, the loop point is, by default, 
+    /// the start of the stream. The loop start point can be set with this parameter, and 
+    /// current loop point can be queried with [getLoopingPoint] and 
+    /// changed by [setLoopingPoint].
     /// Returns the handle of the sound, 0 if error
     FFI_PLUGIN_EXPORT unsigned int play3d(
         unsigned int soundHash,
@@ -737,18 +784,24 @@ extern "C"
         float velY,
         float velZ,
         float volume,
-        bool paused)
+        bool paused,
+        bool looping,
+        double loopingStartAt,
+        unsigned int *handle)
     {
         if (!player.isInited() || player.getSoundsCount() == 0)
-            return 0;
+            return backendNotInited;
 
-        return player.play3d(
+        *handle = player.play3d(
             soundHash,
             posX, posY, posZ,
             velX, velY, velZ,
             volume,
             paused,
-            0);
+            0,
+            looping,
+            loopingStartAt);
+        return *handle == 0 ? soundHashNotFound : noError;
     }
 
     /// You can set and get the current value of the speed of

--- a/src/enums.h
+++ b/src/enums.h
@@ -3,7 +3,7 @@
 #ifndef ENUMS_H
 #define ENUMS_H
 
-/// Possible player errors
+/// Possible player errors. 
 typedef enum PlayerErrors
 {
     /// No error
@@ -25,11 +25,15 @@ typedef enum PlayerErrors
     /// Other error
     unknownError,
     /// Player not initialized
+    nullPointer,
+    /// audio sound hash has not found
+    soundHashNotFound,
+    /// Player not initialized
     backendNotInited,
     /// Filter not found
     filterNotFound,
-    /// audio sound hash has not found
-    soundHashNotFound
+    /// asking for wave and FFT is not enabled
+    visualizationNotEnabled,
 } PlayerErrors_t;
 
 /// Possible capture errors

--- a/src/enums.h
+++ b/src/enums.h
@@ -27,7 +27,9 @@ typedef enum PlayerErrors
     /// Player not initialized
     backendNotInited,
     /// Filter not found
-    filterNotFound
+    filterNotFound,
+    /// audio sound hash has not found
+    soundHashNotFound
 } PlayerErrors_t;
 
 /// Possible capture errors

--- a/src/ffi_gen_tmp.h
+++ b/src/ffi_gen_tmp.h
@@ -24,18 +24,27 @@ struct CaptureDevice
 //--------------------- copy here the new functions to generate
 
 
-
-/// Play already loaded sound identified by [hash]
+/// play3d() is the 3d version of the play() call
 ///
-/// [hash] the unique sound hash of a sound
-/// [volume] 1.0f full volume
-/// [pan] 0.0f centered
-/// [paused] 0 not paused
-/// [newHandle] the handle for this sound
-/// Return the error if any and the [newHandle] of the sound
-FFI_PLUGIN_EXPORT enum PlayerErrors play(
-    unsigned int hash,
+/// [posX], [posY], [posZ] are the audio source position coordinates.
+/// [velX], [velY], [velZ] are the audio source velocity.
+/// [looping] whether to start the sound in looping state.
+/// [loopingStartAt] If looping is enabled, the loop point is, by default, 
+/// the start of the stream. The loop start point can be set with this parameter, and 
+/// current loop point can be queried with [getLoopingPoint] and 
+/// changed by [setLoopingPoint].
+/// Returns the handle of the sound, 0 if error
+FFI_PLUGIN_EXPORT unsigned int play3d(
+    unsigned int soundHash,
+    float posX,
+    float posY,
+    float posZ,
+    float velX,
+    float velY,
+    float velZ,
     float volume,
-    float pan,
     bool paused,
-    unsigned int *newHandle);
+    bool looping,
+    double loopingStartAt,
+    unsigned int *handle);
+    

--- a/src/ffi_gen_tmp.h
+++ b/src/ffi_gen_tmp.h
@@ -25,7 +25,17 @@ struct CaptureDevice
 
 
 
-/// Get visualization state
+/// Play already loaded sound identified by [hash]
 ///
-/// Return true if enabled
-FFI_PLUGIN_EXPORT int getVisualizationEnabled();
+/// [hash] the unique sound hash of a sound
+/// [volume] 1.0f full volume
+/// [pan] 0.0f centered
+/// [paused] 0 not paused
+/// [newHandle] the handle for this sound
+/// Return the error if any and the [newHandle] of the sound
+FFI_PLUGIN_EXPORT enum PlayerErrors play(
+    unsigned int hash,
+    float volume,
+    float pan,
+    bool paused,
+    unsigned int *newHandle);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -254,7 +254,9 @@ unsigned int Player::play(
     unsigned int soundHash,
     float volume,
     float pan,
-    bool paused)
+    bool paused,
+    bool looping,
+    double loopingStartAt)
 {
     auto const &s = std::find_if(sounds.begin(), sounds.end(),
                                  [&](std::unique_ptr<ActiveSound> const &f)
@@ -264,8 +266,15 @@ unsigned int Player::play(
         return 0;
 
     ActiveSound *sound = s->get();
-    SoLoud::handle newHandle = soloud.play(*sound->sound.get(), volume, pan, paused, 0);
-    sound->handle.emplace_back(newHandle);
+    SoLoud::handle newHandle = soloud.play(*sound->sound.get(), volume, pan, looping ? true : paused, 0);
+    if (newHandle != 0) sound->handle.emplace_back(newHandle);
+    if (looping)
+    {
+        seek(newHandle, loopingStartAt);
+        setLoopPoint(newHandle, loopingStartAt);
+        setLooping(newHandle, true);
+        setPause(newHandle, paused);
+    }
     return newHandle;
 }
 
@@ -304,9 +313,24 @@ void Player::disposeAllSound()
     sounds.clear();
 }
 
+bool Player::getLooping(unsigned int handle)
+{
+    return soloud.getLooping(handle);
+}
+
 void Player::setLooping(unsigned int handle, bool enable)
 {
     soloud.setLooping(handle, enable);
+}
+
+double Player::getLoopPoint(unsigned int handle)
+{
+    return soloud.getLoopPoint(handle);
+}
+
+void Player::setLoopPoint(unsigned int handle, double time)
+{
+    soloud.setLoopPoint(handle, time);
 }
 
 PlayerErrors Player::textToSpeech(const std::string &textToSpeech, unsigned int &handle)
@@ -513,15 +537,17 @@ void Player::update3dAudio()
 
 unsigned int Player::play3d(
     unsigned int soundHash,
-    float aPosX,
-    float aPosY,
-    float aPosZ,
-    float aVelX,
-    float aVelY,
-    float aVelZ,
-    float aVolume,
-    bool aPaused,
-    unsigned int aBus)
+    float posX,
+    float posY,
+    float posZ,
+    float velX,
+    float velY,
+    float velZ,
+    float volume,
+    bool paused,
+    unsigned int bus,
+    bool looping,
+    double loopingStartAt)
 {
     auto const &s = std::find_if(sounds.begin(), sounds.end(),
                                  [&](std::unique_ptr<ActiveSound> const &f)
@@ -532,12 +558,19 @@ unsigned int Player::play3d(
     ActiveSound *sound = s->get();
     SoLoud::handle newHandle = soloud.play3d(
         *sound->sound.get(),
-        aPosX, aPosY, aPosZ,
-        aVelX, aVelY, aVelZ,
-        aVolume,
-        aPaused,
-        aBus);
-    sound->handle.emplace_back(newHandle);
+        posX, posY, posZ,
+        velX, velY, velZ,
+        volume,
+        paused,
+        bus);
+    if (newHandle != 0) sound->handle.emplace_back(newHandle);
+    if (looping)
+    {
+        seek(newHandle, loopingStartAt);
+        setLoopPoint(newHandle, loopingStartAt);
+        setLooping(newHandle, true);
+        setPause(newHandle, paused);
+    }
     return newHandle;
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -266,10 +266,15 @@ unsigned int Player::play(
         return 0;
 
     ActiveSound *sound = s->get();
+    /// When looping in conjuction with the `loopingStartAt`, it's needed
+    /// to seek to the start loop point. So the seek will be performed in a paused state.
     SoLoud::handle newHandle = soloud.play(*sound->sound.get(), volume, pan, looping ? true : paused, 0);
     if (newHandle != 0) sound->handle.emplace_back(newHandle);
     if (looping)
     {
+        /// here a seek is needed because at first loop the sound start 
+        /// from the beginning. From the 2nd and above, the starting point
+        /// is managed correctly.
         seek(newHandle, loopingStartAt);
         setLoopPoint(newHandle, loopingStartAt);
         setLooping(newHandle, true);

--- a/src/player.h
+++ b/src/player.h
@@ -129,12 +129,19 @@ public:
     /// @param volume 1.0f full volume.
     /// @param pan 0.0f centered.
     /// @param paused 0 not pause.
+    /// @param looping whether to start the sound in looping state.
+    /// @param loopingStartAt If looping is enabled, the loop point is, by default, 
+    /// the start of the stream. The loop start point can be set with this parameter, and 
+    /// current loop point can be queried with [getLoopingPoint] and 
+    /// changed by [setLoopingPoint].
     /// @return the handle of the sound, 0 if error.
     unsigned int play(
         unsigned int soundHash,
         float volume = 1.0f,
         float pan = 0.0f,
-        bool paused = 0);
+        bool paused = false,
+        bool looping = false,
+        double loopingStartAt = 0.0);
 
     /// @brief Stop already loaded sound identified by [handle] and clear it.
     /// @param handle
@@ -148,11 +155,23 @@ public:
     /// @param soundHash
     void disposeAllSound();
 
+    /// @brief Query whether a sound is set to loop.
+    bool getLooping(unsigned int handle);
+
     /// @brief This function can be used to set a sample to play on repeat, 
     /// instead of just playing once.
     /// @param handle
     /// @param enable
     void setLooping(unsigned int handle, bool enable);
+
+    /// @brief Get sound loop point value.
+    /// @return the time in seconds.
+    double getLoopPoint(unsigned int handle);
+
+    /// @brief Set sound loop point value.
+    /// @param handle 
+    /// @param time in seconds.
+    void setLoopPoint(unsigned int handle, double time);
 
     /// @brief Speech
     /// @param textToSpeech
@@ -249,6 +268,11 @@ public:
     void update3dAudio();
 
     /// @brief play3d() is the 3d version of the play() call.
+    /// @param looping whether to start the sound in looping state.
+    /// @param loopingStartAt If looping is enabled, the loop point is, by default, 
+    /// the start of the stream. The loop start point can be set with this parameter, and 
+    /// current loop point can be queried with [getLoopingPoint] and 
+    /// changed by [setLoopingPoint].
     /// @return the handle of the sound, 0 if error.
     unsigned int play3d(
         unsigned int soundHash,
@@ -260,7 +284,9 @@ public:
         float velZ = 0.0f,
         float volume = 1.0f,
         bool paused = 0,
-        unsigned int bus = 0);
+        unsigned int bus = 0,
+        bool looping = false,
+        double loopingStartAt = 0.0);
 
     /// You can set and get the current value of the speed of
     /// sound width the get3dSoundSpeed() and set3dSoundSpeed() functions.


### PR DESCRIPTION
## Description

Now `SoLoud.play()` and `SoLoud.play3d()` have also `looping` and `loopingStartAt` properties. They also can be set/get at any time with `SoLoud.getLoopPoint()` and `SoLoud.setLoopPoint()`.
Added `SoLoud.getLooping()` to get the looping state.
To test them I used the example app: in the 3D page the siren loop is played with `looping` property, in multi track page there is a check box and a slider to control these values.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
