### PR TITLE
Implement loader in SoLoud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@
 - All fields of `SoundProps` marked `final`. This is a breaking change
   but unlikely to have effect (as most users hopefully don't assign
   to these fields).
+- New methods `SoLoud.loadAsset()` and `SoLoud.loadUrl()` to load audio
+  from assets and URLs, respectively. These replace the old 
+  `SoloudTools.loadFrom*` methods (which are now deprecated).
+    - The new methods also correctly invalidate the temporary files
+      (for example, when an asset changes between versions of the app,
+      we don't want to play the old file).
 
 #### 1.2.5 (2 Mar 2024)
 - updated mp3, flac and wav decoders

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_soloud/flutter_soloud.dart';
 import 'package:flutter_soloud_example/controls.dart';
 import 'package:flutter_soloud_example/page_3d_audio.dart';
 import 'package:flutter_soloud_example/page_hello_flutter.dart';

--- a/example/lib/main_wav_stream.dart
+++ b/example/lib/main_wav_stream.dart
@@ -102,8 +102,10 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> addSound(String file) async {
     var l = 0.0;
-    final s = await SoloudTools.loadFromFile(file, mode: LoadMode.disk);
-    sounds.add(s!);
+    final ret = await SoLoud.instance.loadFile(file, mode: LoadMode.disk);
+    assert(ret.error == PlayerErrors.noError, 'Error: ${ret.error}');
+    final s = ret.sound!;
+    sounds.add(s);
     l = SoLoud.instance.getLength(s).length;
     if (l < minLength) minLength = l;
   }

--- a/example/lib/page_3d_audio.dart
+++ b/example/lib/page_3d_audio.dart
@@ -95,9 +95,11 @@ class _Page3DAudioState extends State<Page3DAudio> {
     }
 
     /// load the audio file
-    currentSound = await SoloudTools.loadFromUrl(
+    final ret = await SoLoud.instance.loadUrl(
       'https://www.learningcontainer.com/wp-content/uploads/2020/02/Kalimba.mp3',
     );
+    if (ret.error != PlayerErrors.noError) return;
+    currentSound = ret.sound;
 
     /// play it
     final playRet = await SoLoud.instance.play3d(currentSound!, 0, 0, 0);
@@ -123,7 +125,9 @@ class _Page3DAudioState extends State<Page3DAudio> {
     }
 
     /// load the audio file
-    currentSound = await SoloudTools.loadFromAssets('assets/audio/siren.mp3');
+    final ret = await SoLoud.instance.loadAsset('assets/audio/siren.mp3');
+    if (ret.error != PlayerErrors.noError) return;
+    currentSound = ret.sound;
 
     /// play it
     final playRet = await SoLoud.instance.play3d(currentSound!, 0, 0, 0);

--- a/example/lib/page_hello_flutter.dart
+++ b/example/lib/page_hello_flutter.dart
@@ -126,8 +126,9 @@ class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
     }
 
     /// load the audio file
-    final newSound = await SoloudTools.loadFromFile(file);
-    if (newSound == null) return;
+    final ret = await SoLoud.instance.loadFile(file);
+    if (ret.error != PlayerErrors.noError) return;
+    final newSound = ret.sound!;
     currentSound = newSound;
 
     /// play it

--- a/example/lib/page_waveform.dart
+++ b/example/lib/page_waveform.dart
@@ -57,10 +57,10 @@ class _PageWaveformState extends State<PageWaveform> {
         /// Only when the [notes] are set up, build the UI
         setupNotes().then((value) {
           if (context.mounted) {
-          setState(() {
-            canBuild = true;
-          });
-        }
+            setState(() {
+              canBuild = true;
+            });
+          }
         });
       } else {
         _log.severe('player starting error: $value');
@@ -114,11 +114,15 @@ class _PageWaveformState extends State<PageWaveform> {
                 const SizedBox(width: 8),
                 ElevatedButton(
                   onPressed: () async {
-                    final ret = await SoloudTools.loadFromAssets(
+                    final ret = await SoLoud.instance.loadAsset(
                       'assets/audio/8_bit_mentality.mp3',
                     );
+                    if (ret.error != PlayerErrors.noError) {
+                      _log.severe('error loading sample: ${ret.error}');
+                      return;
+                    }
                     await SoLoud.instance
-                        .play(ret!)
+                        .play(ret.sound!)
                         .then((value) => sound = value.sound);
                   },
                   child: const Text('play sample'),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.5"
+    version: "2.0.0-pre.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -242,9 +242,8 @@ Future<void> dispose() async {
 }
 
 Future<void> loadAsset() async {
-  currentSound = await SoloudTools.loadFromAssets(
-    'assets/audio/explosion.mp3',
-  );
+  final ret = await SoLoud.instance.loadAsset('assets/audio/explosion.mp3');
+  currentSound = ret.sound;
   assert(currentSound != null, 'loadFromAssets() failed!');
 
   currentSound!.soundEvents.stream.listen((event) {

--- a/lib/flutter_soloud.dart
+++ b/lib/flutter_soloud.dart
@@ -3,6 +3,7 @@
 library flutter_soloud;
 
 export 'src/enums.dart';
+export 'src/exceptions.dart';
 export 'src/filter_params.dart';
 export 'src/soloud.dart';
 export 'src/soloud_capture.dart';

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -122,7 +122,7 @@ class FlutterSoLoudFfi {
   /// If `LoadMode.disk` is used, the audio data is loaded
   /// from the given file when needed (more CPU, less memory allocated).
   /// See the [seek] note problem when using [LoadMode] = `LoadMode.disk`.
-  /// [soundHash] return hash of the sound.
+  /// `soundHash` return hash of the sound.
   /// Returns [PlayerErrors.noError] if success.
   ({PlayerErrors error, SoundHash soundHash}) loadFile(
     String completeFileName,
@@ -158,7 +158,7 @@ class FlutterSoLoudFfi {
   /// [superWave]
   /// [scale]
   /// [detune]
-  /// [soundHash] return hash of the sound
+  /// `soundHash` return hash of the sound
   /// Returns [PlayerErrors.noError] if success
   ({PlayerErrors error, SoundHash soundHash}) loadWaveform(
     WaveForm waveform,

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -110,7 +110,10 @@ enum PlayerErrors {
   filterNotFound,
 
   /// asking for wave and FFT is not enabled
-  visualizationNotEnabled;
+  visualizationNotEnabled,
+
+  /// Asset was found but for some reason couldn't be loaded.
+  assetLoadFailed;
 
   /// Returns a human-friendly sentence describing the error.
   String get _asSentence {
@@ -164,6 +167,10 @@ enum PlayerErrors {
       case PlayerErrors.visualizationNotEnabled:
         return 'Asking for audio data is not enabled! Please use '
             '`setVisualizationEnabled(true);` to enable!';
+      case PlayerErrors.assetLoadFailed:
+        return "Asset was found but for some reason couldn't be loaded. "
+            'This could be a problem with the temporary directory into which '
+            'the asset is being copied.';
     }
   }
 

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,0 +1,14 @@
+/// Exception thrown when a network request (in `SoLoud.loadUrl()`) fails.
+class SoLoudNetworkException implements Exception {
+  /// Constructs the exception.
+  const SoLoudNetworkException(this.message, {required this.statusCode});
+
+  /// The message describing the failure.
+  final String message;
+
+  /// The HTTP status code of the failure.
+  final int statusCode;
+
+  @override
+  String toString() => '$message (HTTP $statusCode)';
+}

--- a/lib/src/tools/soloud_tools.dart
+++ b/lib/src/tools/soloud_tools.dart
@@ -7,6 +7,7 @@ import 'package:flutter_soloud/src/soloud.dart';
 import 'package:flutter_soloud/src/utils/assets_manager.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
 /// The `SoloudTools` class provides static methods to load audio files
@@ -16,7 +17,7 @@ class SoloudTools {
   static final Logger _log = Logger('flutter_soloud.SoloudTools');
 
   /// Loads an audio file from the assets folder.
-  ///
+  @Deprecated('Use SoLoud.loadAsset() instead')
   static Future<SoundProps?> loadFromAssets(
     String path, {
     LoadMode mode = LoadMode.memory,
@@ -31,7 +32,7 @@ class SoloudTools {
   }
 
   /// Loads an audio file from the local file system.
-  ///
+  @Deprecated('Use SoLoud.loadFile() instead')
   static Future<SoundProps?> loadFromFile(
     String path, {
     LoadMode mode = LoadMode.memory,
@@ -46,7 +47,7 @@ class SoloudTools {
   }
 
   /// Fetches an audio file from a URL and loads it into the memory.
-  ///
+  @Deprecated('Use SoLoud.loadUrl() instead')
   static Future<SoundProps?> loadFromUrl(
     String url, {
     LoadMode mode = LoadMode.memory,
@@ -54,7 +55,7 @@ class SoloudTools {
     try {
       final tempDir = await getTemporaryDirectory();
       final tempPath = tempDir.path;
-      final filePath = '$tempPath${Platform.pathSeparator}${shortHash(url)}';
+      final filePath = path.join(tempPath, shortHash(url));
       final file = File(filePath);
 
       if (!file.existsSync()) {

--- a/lib/src/utils/loader.dart
+++ b/lib/src/utils/loader.dart
@@ -1,0 +1,300 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_soloud/src/exceptions.dart';
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart' as path_provider;
+
+/// A long-living helper class that loads assets and URLs into temporary files
+/// that can be played by SoLoud.
+@internal
+class SoLoudLoader {
+  SoLoudLoader();
+
+  static const String _temporaryDirectoryName = 'SoLoudLoader-Temp-Files';
+
+  static final Logger _log = Logger('flutter_soloud.SoLoudLoader');
+
+  /// When `true`, the loader will automatically call [cleanUp],
+  /// deleting files in the temporary directory at various points.
+  bool automaticCleanup = false;
+
+  final Map<_TemporaryFileIdentifier, File> _temporaryFiles = {};
+
+  Directory? _temporaryDirectory;
+
+  /// Deletes temporary files. It is good practice to call this method
+  /// once in a while, in order not to bloat the temporary directory.
+  /// This is especially important when the application plays a lot of
+  /// different files during its lifetime (e.g. a music player
+  /// loading tracks from the network).
+  ///
+  /// For applications and games that play sounds from assets or from
+  /// the file system, this is probably unnecessary, as the amount of data will
+  /// be finite.
+  Future<void> cleanUp() async {
+    _log.finest('cleanUp() called');
+    final directory = _temporaryDirectory;
+
+    if (directory == null) {
+      _log.warning("Temporary directory hasn't been initialized, "
+          'yet cleanUp() is called.');
+      return;
+    }
+
+    // Clear the set in case someone tries to access the files
+    // while we're deleting them.
+    _temporaryFiles.clear();
+
+    try {
+      final files = await directory.list(followLinks: false).toList();
+
+      Future<bool> deleteFile(FileSystemEntity entity) async {
+        try {
+          await entity.delete(recursive: true);
+        } on FileSystemException catch (e) {
+          _log.warning(() => 'cleanUp() cannot remove ${entity.path}: $e');
+          return false;
+        }
+        return true;
+      }
+
+      // Delete files in parallel.
+      final results = await Future.wait(files.map(deleteFile));
+
+      if (results.any((success) => !success)) {
+        _log.severe('Cannot clean up temporary directory. See warnings above.');
+      }
+
+      await _temporaryDirectory?.delete(recursive: true);
+    } on FileSystemException catch (e) {
+      _log.severe('Cannot clean up temporary directory: $e');
+    }
+  }
+
+  /// This method can be run safely several times.
+  Future<void> initialize() async {
+    _log.finest('initialize() called');
+    if (_temporaryDirectory != null) {
+      _log.fine(
+        () => 'Loader has already been initialized. Not initializing again.',
+      );
+      if (automaticCleanup) {
+        await cleanUp();
+      }
+      return;
+    }
+
+    final systemTempDir = await path_provider.getTemporaryDirectory();
+    final directoryPath =
+        path.join(systemTempDir.path, _temporaryDirectoryName);
+    final directory = Directory(directoryPath);
+
+    try {
+      _temporaryDirectory = await directory.create();
+    } catch (e) {
+      _log.severe(
+        "Couldn't initialize loader. Temporary directory couldn't be created.",
+        e,
+      );
+      // There is no way we can recover from this. If we have nowhere to save
+      // files, we can't play anything.
+      rethrow;
+    }
+
+    _log.info(() => 'Temporary directory initialized at ${directory.path}');
+
+    if (automaticCleanup) {
+      await cleanUp();
+    }
+  }
+
+  /// Loads the asset with [key] (e.g. `assets/sound.mp3`), and creates
+  /// a temporary file that can be played by SoLoud.
+  ///
+  /// Provide [assetBundle] if needed. By default, the method uses
+  /// [rootBundle].
+  ///
+  /// Returns `null` if there's a problem with some implementation detail
+  /// (e.g. cannot create temporary file).
+  ///
+  /// Throws an exception when the asset doesn't exist or cannot be loaded.
+  /// (This is the same exception that [AssetBundle.load] would throw.)
+  Future<File?> loadAsset(
+    String key, {
+    AssetBundle? assetBundle,
+  }) async {
+    final id = _TemporaryFileIdentifier(_Source.asset, key);
+
+    // TODO(filiph): Add the option to check the filesystem first.
+    //               This could be a cache-invalidation problem (if the asset
+    //               changes from one version to another). But it could speed
+    //               up start up times.
+    if (_temporaryFiles.containsKey(id)) {
+      final existingFile = _temporaryFiles[id]!;
+      if (existingFile.existsSync()) {
+        _log.finest(() => 'Asset $key already exists as a temporary file.');
+        return _temporaryFiles[id];
+      }
+    }
+
+    final directory = _temporaryDirectory;
+
+    if (directory == null) {
+      _log.severe("Temporary directory hasn't been initialized, "
+          'yet loadAsset() is called.');
+      return null;
+    }
+
+    final newFilepath = _getFullTempFilePath(id);
+    final newFile = File(newFilepath);
+
+    final ByteData byteData;
+    final bundle = assetBundle ?? rootBundle;
+
+    try {
+      byteData = await bundle.load(key);
+    } catch (e) {
+      _log.severe("loadAsset() couldn't load $key from $bundle", e);
+      // Fail-fast principle. If the developer tries to load an asset
+      // that's not available, this should be seen during debugging,
+      // and the developer should be able to catch and deal with the error
+      // in a try-catch block.
+      rethrow;
+    }
+
+    final buffer = byteData.buffer;
+    try {
+      await newFile.create(recursive: true);
+      await newFile.writeAsBytes(
+        buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes),
+      );
+    } catch (e, s) {
+      _log.severe("loadAsset() couldn't write $newFile to disk", e, s);
+      return null;
+    }
+
+    _temporaryFiles[id] = newFile;
+
+    return newFile;
+  }
+
+  /// Optionally, you can provide your own [httpClient]. This is a good idea
+  /// if you're loading several files in a short span of time (such as
+  /// on program startup). When no [httpClient] is provided, this method
+  /// will create a new one and close it afterwards.
+  ///
+  /// Throws [FormatException] if the [url] is invalid.
+  /// Throws [SoLoudNetworkException] if the request fails.
+  Future<File?> loadUrl(
+    String url, {
+    http.Client? httpClient,
+  }) async {
+    final uri = Uri.parse(url);
+
+    final id = _TemporaryFileIdentifier(_Source.url, url);
+
+    // TODO(filiph): Add the option to check the filesystem first.
+    //               This could be a cache-invalidation problem (if the asset
+    //               changes from one version to another). But it could speed
+    //               up start up times.
+    if (_temporaryFiles.containsKey(id)) {
+      final existingFile = _temporaryFiles[id]!;
+      if (existingFile.existsSync()) {
+        _log.finest(
+          () => 'Sound from $url already exists as a temporary file.',
+        );
+        return _temporaryFiles[id];
+      }
+    }
+
+    final directory = _temporaryDirectory;
+
+    if (directory == null) {
+      _log.severe("Temporary directory hasn't been initialized, "
+          'yet loadUrl() is called.');
+      return null;
+    }
+
+    final newFilepath = _getFullTempFilePath(id);
+    final newFile = File(newFilepath);
+
+    final Uint8List byteData;
+
+    try {
+      http.Response response;
+      if (httpClient != null) {
+        response = await httpClient.get(uri);
+      } else {
+        response = await http.get(uri);
+      }
+      if (response.statusCode == 200) {
+        byteData = response.bodyBytes;
+      } else {
+        throw SoLoudNetworkException(
+          'Failed to fetch file from URL: $url',
+          statusCode: response.statusCode,
+        );
+      }
+    } catch (e) {
+      _log.severe(() => 'Error fetching $url', e);
+      rethrow;
+    }
+
+    final buffer = byteData.buffer;
+    try {
+      await newFile.create(recursive: true);
+      await newFile.writeAsBytes(
+        buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes),
+      );
+    } catch (e, s) {
+      _log.severe("loadUrl() couldn't write $newFile to disk", e, s);
+      return null;
+    }
+
+    _temporaryFiles[id] = newFile;
+
+    return newFile;
+  }
+
+  String _getFullTempFilePath(_TemporaryFileIdentifier id) {
+    final directory = _temporaryDirectory;
+
+    if (directory == null) {
+      throw StateError("Temporary directory hasn't been initialized, "
+          'yet _getTempFile() is called.');
+    }
+
+    return path.join(directory.absolute.path, id.asFilename);
+  }
+}
+
+enum _Source {
+  url,
+  asset,
+}
+
+@immutable
+class _TemporaryFileIdentifier {
+  const _TemporaryFileIdentifier(this.source, this.path);
+
+  final _Source source;
+
+  final String path;
+
+  String get asFilename =>
+      'temp-sound-${source.name}-0x${path.hashCode.toRadixString(16)}';
+
+  @override
+  int get hashCode => Object.hash(source, path);
+
+  @override
+  bool operator ==(Object other) {
+    return other is _TemporaryFileIdentifier &&
+        other.source == source &&
+        other.path == path;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   logging: ^1.0.0
   #https://pub.dev/packages/meta
   meta: ^1.0.0
+  #https://pub.dev/packages/path
+  path: ^1.8.1
   #https://pub.dev/packages/path_provider
   path_provider: ^2.0.15
   


### PR DESCRIPTION
## Description

- New methods `SoLoud.loadAsset()` and `SoLoud.loadUrl()` to load audio
  from assets and URLs, respectively. These replace the old 
  `SoloudTools.loadFrom*` methods (which are now deprecated).
    - The new methods also correctly invalidate the temporary files
      (for example, when an asset changes between versions of the app,
      we don't want to play the old file).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
