### PR TITLE
Rename SoundProps to AudioSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ to `2.0.0-pre.2` and beyond.
 - Renamed `SoLoud.setFxParams` to `SoLoud.setFilterParameter`. 
   This mimics the C++ API name.
   Quick fix available.
+- Renamed `SoundProps` to `AudioSource`. Quick fix available.
 
 #### 2.0.0-pre.1 (12 Mar 2024)
 - added `looping` and `loopingStartAt` properties to `SoLoud.play()` and `SoLoud.play3d()`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ https://github.com/alnitak/flutter_soloud/assets/192827/92c9db80-80ee-4a27-b6a9-
 https://github.com/alnitak/flutter_soloud/assets/192827/f7cf9d71-be4f-4c83-99ff-89dbd9378859
 
 
-***The 5th*** example shows how to generete [**SoundProps**] key sounds. There is a handy tool method to generate the 12 key notes of a given octave. A widget to play them can be used with the touch or a keyboard. Different types of waveforms can be chosen including square,`saw`,`sin`,`triangle`,`bounce`,`jaws`,`humps`,`fSquare` and `fSaw`.
+***The 5th*** example shows how to generete [**AudioSource**] key sounds. There is a handy tool method to generate the 12 key notes of a given octave. A widget to play them can be used with the touch or a keyboard. Different types of waveforms can be chosen including square,`saw`,`sin`,`triangle`,`bounce`,`jaws`,`humps`,`fSquare` and `fSaw`.
 There are also simple knobs to adjust faders and oscillators. Other knobs to add/remove audio effects.
 
 https://github.com/alnitak/flutter_soloud/assets/192827/bfc5aa73-6dbc-42f5-90e4-bc1cc5e181e0
@@ -91,7 +91,7 @@ Future<bool> start() async{
 ```
 When succesfully started a sound can be loaded:
 ```
-Future<SoundProps?> loadSound(String completeFileName) {
+Future<AudioSource?> loadSound(String completeFileName) {
   final load = await SoLoud().loadFile(completeFileName);
   if (load.error != PlayerErrors.noError) return null;
   return load.sound;
@@ -99,14 +99,14 @@ Future<SoundProps?> loadSound(String completeFileName) {
 ```
 
 There are 3 convenient methods that can be used instead in the [SoloudLoadingTool] class:
-- ```Future<SoundProps?> loadFromAssets(String path)```
-- ```Future<SoundProps?> loadFromFile(String path)```
-- ```Future<SoundProps?> loadFromUrl(String url)```
+- ```Future<AudioSource?> loadFromAssets(String path)```
+- ```Future<AudioSource?> loadFromFile(String path)```
+- ```Future<AudioSource?> loadFromUrl(String url)```
 
-The [SoundProps] class:
+The [AudioSource] class:
 ```
-class SoundProps {
-  SoundProps(this.soundHash);
+class AudioSource {
+  AudioSource(this.soundHash);
 
   // the [hash] returned by [loadFile]
   final int soundHash;
@@ -121,7 +121,7 @@ class SoundProps {
 ```
 *soundHash* and *handle* list are then used to call many methods in the *AudioIsolate()* class.
 
-**warning**: when you call a load* method, in return you will get a SoundProps. This is the reference to the sound which is used by SoLoud and need to be disposed when is no more needed. When you play a SoundsProps, intstead a new handle, to identify the new playing instance, is created and added to SoundProps.handle list. This let you play the sound as many times you want without calling a load* method again which can be laggy.
+**warning**: when you call a load* method, in return you will get a AudioSource. This is the reference to the sound which is used by SoLoud and need to be disposed when is no more needed. When you play a SoundsProps, intstead a new handle, to identify the new playing instance, is created and added to AudioSource.handle list. This let you play the sound as many times you want without calling a load* method again which can be laggy.
 To dispose a sound call you should call *Soloud().disposeSound* or *Soloud().disposeAllSounds*
 
 #### Capture from microphone
@@ -148,50 +148,50 @@ The `AudioIsolate` instance has the duty of receiving commands and sending them 
 
 
 #### Player methods
-| Function| Returns| Params| Description|
-|---------|---------|---------|--------------------------------------------------------------------------------------------|
-| **startIsolate**| PlayerErrors| -| Start the audio isolate and listen for messages coming from it.|
-| **stopIsolate**| bool| -| Stop the loop, stop the engine, and kill the isolate. Must be called when there is no more need for the player or when closing the app.|
-| **isIsolateRunning**| bool| -| Return true if the audio isolate is running.|
-| **initEngine**| PlayerErrors| -| Initialize the audio engine. Defaults are: Sample rate 44100, buffer 2048, and Miniaudio audio backend.|
-| **dispose**| -| -| Stop the audio engine.|
-| **loadFile**| ({PlayerErrors error, SoundProps? sound})|`String` fileName, <br/>`LoadMode` mode = LoadMode.memory| Load a new sound to be played once or multiple times later.<br/>If `mode = LoadMode.disk`, seek will have lags with MP3s.|
-| **play**| ({PlayerErrors error, SoundProps sound, int newHandle})| `int` soundHash, {<br/>`double` volume = 1,<br/>`double` pan = 0,<br/>`bool` paused = false,<br/>}| Play an already loaded sound identified by [sound].|
-| **speechText**| ({PlayerErrors error, SoundProps sound})| `String` textToSpeech| Speech from the given text.|
-| **pauseSwitch**| PlayerErrors| `int` handle| Pause or unpause an already loaded sound identified by [handle].|
-| **getPause**| ({PlayerErrors error, bool pause})| `int` handle| Get the pause state of the sound identified by [handle].|
-| **setRelativePlaySpeed**| PlayerErrors| `int` handle, `double` speed| Set a sound's relative play speed.|
-| **getRelativePlaySpeed**| ({PlayerErrors error, double speed})| `int` handle| Return the current play speed.|
-| **stop**| PlayerErrors| `int` handle| Stop an already loaded sound identified by [handle] and clear it.|
-| **disposeSound**| PlayerErrors| `int` handle| Stop ALL handles of the already loaded sound identified by [soundHash] and dispose it.|
-| **getLooping**| ({PlayerErrors error, bool isLooping})| -| Query whether a sound is set to loop.|
-| **setLooping**| -| `int` handle, `bool` enable| This function can be used to set a sample to play on repeat, instead of just playing once.|
-| **getLoopPoint**| ({PlayerErrors error, double time})| -| Get sound loop point value.|
-| **setLoopPoint**| PlayerErrors| `SoundHandle` handle, `double` time| Set sound loop point value.|
-| **getLength**| ({PlayerErrors error, double length})| `int` soundHash| Get the sound length in seconds.|
-| **seek**| PlayerErrors| `int` handle, `double` time| Seek playing in seconds.<br/>WARNING: when loading an MP3 file with `mode = LoadMode.disk`, the seek is laggy. This should not happens with FLACs, OGGs and WAVs.|
-| **getPosition**| ({PlayerErrors error, double position})| `int` handle| Get the current sound position in seconds.|
-| **getVolume**| ({PlayerErrors error, double volume})| `int` handle| Get current [handle] volume.|
-| **setVolume**| ({PlayerErrors error, double volume})| `int` handle, `double` volume| set  [handle] volume.|
-| **getIsValidVoiceHandle**| ({PlayerErrors error, bool isValid})| `int` handle| Check if a handle is still valid.|
-| **setVisualizationEnabled**| -| `bool` enabled| Enable or disable getting data from `getFft`, `getWave`, `getAudioTexture*`.|
-| **getVisualizationEnabled**| ({PlayerErrors error, bool isEnabled})| -| Get the state of visualization flag.|
-| **getFft**| -| `Pointer<Float>` fft| Returns a 256 float array containing FFT data.|
-| **getWave**| -| `Pointer<Float>` wave| Returns a 256 float array containing wave data (magnitudes).|
-| **getAudioTexture**| -| `Pointer<Float>` samples| Returns in `samples` a 512 float array.<br/>- The first 256 floats represent the FFT frequencies data [>=0.0].<br/>- The other 256 floats represent the wave data (amplitude) [-1.0~1.0].|
-| **getAudioTexture2D**| -| `Pointer<Pointer<Float>>` samples| Return a floats matrix of 256x512.<br/>Every row is composed of 256 FFT values plus 256 wave data.<br/>Every time is called, a new row is stored in the first row and all the previous rows are shifted up (the last will be lost).|
-| **setFftSmoothing**| -| `double` smooth| Smooth FFT data.<br/>When new data is read and the values are decreasing, the new value will be decreased with an amplitude between the old and the new value.<br/> This will result in a less shaky visualization.<br/>0 = no smooth<br/>1 = full smooth<br/>The new value is calculated with:<br/>`newFreq = smooth * oldFreq + (1 - smooth) * newFreq`|
+| Function| Returns                                                  | Params| Description|
+|---------|----------------------------------------------------------|---------|--------------------------------------------------------------------------------------------|
+| **startIsolate**| PlayerErrors                                             | -| Start the audio isolate and listen for messages coming from it.|
+| **stopIsolate**| bool                                                     | -| Stop the loop, stop the engine, and kill the isolate. Must be called when there is no more need for the player or when closing the app.|
+| **isIsolateRunning**| bool                                                     | -| Return true if the audio isolate is running.|
+| **initEngine**| PlayerErrors                                             | -| Initialize the audio engine. Defaults are: Sample rate 44100, buffer 2048, and Miniaudio audio backend.|
+| **dispose**| -                                                        | -| Stop the audio engine.|
+| **loadFile**| ({PlayerErrors error, AudioSource? sound})               |`String` fileName, <br/>`LoadMode` mode = LoadMode.memory| Load a new sound to be played once or multiple times later.<br/>If `mode = LoadMode.disk`, seek will have lags with MP3s.|
+| **play**| ({PlayerErrors error, AudioSource sound, int newHandle}) | `int` soundHash, {<br/>`double` volume = 1,<br/>`double` pan = 0,<br/>`bool` paused = false,<br/>}| Play an already loaded sound identified by [sound].|
+| **speechText**| ({PlayerErrors error, AudioSource sound})                | `String` textToSpeech| Speech from the given text.|
+| **pauseSwitch**| PlayerErrors                                             | `int` handle| Pause or unpause an already loaded sound identified by [handle].|
+| **getPause**| ({PlayerErrors error, bool pause})                       | `int` handle| Get the pause state of the sound identified by [handle].|
+| **setRelativePlaySpeed**| PlayerErrors                                             | `int` handle, `double` speed| Set a sound's relative play speed.|
+| **getRelativePlaySpeed**| ({PlayerErrors error, double speed})                     | `int` handle| Return the current play speed.|
+| **stop**| PlayerErrors                                             | `int` handle| Stop an already loaded sound identified by [handle] and clear it.|
+| **disposeSound**| PlayerErrors                                             | `int` handle| Stop ALL handles of the already loaded sound identified by [soundHash] and dispose it.|
+| **getLooping**| ({PlayerErrors error, bool isLooping})                   | -| Query whether a sound is set to loop.|
+| **setLooping**| -                                                        | `int` handle, `bool` enable| This function can be used to set a sample to play on repeat, instead of just playing once.|
+| **getLoopPoint**| ({PlayerErrors error, double time})                      | -| Get sound loop point value.|
+| **setLoopPoint**| PlayerErrors                                             | `SoundHandle` handle, `double` time| Set sound loop point value.|
+| **getLength**| ({PlayerErrors error, double length})                    | `int` soundHash| Get the sound length in seconds.|
+| **seek**| PlayerErrors                                             | `int` handle, `double` time| Seek playing in seconds.<br/>WARNING: when loading an MP3 file with `mode = LoadMode.disk`, the seek is laggy. This should not happens with FLACs, OGGs and WAVs.|
+| **getPosition**| ({PlayerErrors error, double position})                  | `int` handle| Get the current sound position in seconds.|
+| **getVolume**| ({PlayerErrors error, double volume})                    | `int` handle| Get current [handle] volume.|
+| **setVolume**| ({PlayerErrors error, double volume})                    | `int` handle, `double` volume| set  [handle] volume.|
+| **getIsValidVoiceHandle**| ({PlayerErrors error, bool isValid})                     | `int` handle| Check if a handle is still valid.|
+| **setVisualizationEnabled**| -                                                        | `bool` enabled| Enable or disable getting data from `getFft`, `getWave`, `getAudioTexture*`.|
+| **getVisualizationEnabled**| ({PlayerErrors error, bool isEnabled})                   | -| Get the state of visualization flag.|
+| **getFft**| -                                                        | `Pointer<Float>` fft| Returns a 256 float array containing FFT data.|
+| **getWave**| -                                                        | `Pointer<Float>` wave| Returns a 256 float array containing wave data (magnitudes).|
+| **getAudioTexture**| -                                                        | `Pointer<Float>` samples| Returns in `samples` a 512 float array.<br/>- The first 256 floats represent the FFT frequencies data [>=0.0].<br/>- The other 256 floats represent the wave data (amplitude) [-1.0~1.0].|
+| **getAudioTexture2D**| -                                                        | `Pointer<Pointer<Float>>` samples| Return a floats matrix of 256x512.<br/>Every row is composed of 256 FFT values plus 256 wave data.<br/>Every time is called, a new row is stored in the first row and all the previous rows are shifted up (the last will be lost).|
+| **setFftSmoothing**| -                                                        | `double` smooth| Smooth FFT data.<br/>When new data is read and the values are decreasing, the new value will be decreased with an amplitude between the old and the new value.<br/> This will result in a less shaky visualization.<br/>0 = no smooth<br/>1 = full smooth<br/>The new value is calculated with:<br/>`newFreq = smooth * oldFreq + (1 - smooth) * newFreq`|
 
 
 #### Waveform
-| Function| Returns| Params| Description|
-|---------|--------|-------|------------|
-| **loadWaveform**| ({PlayerErrors error, SoundProps? sound})| `WaveForm` waveform<br/>`bool` superWave<br/>`double` scale<br/>`double` detune| Load a new sound to be played.|
-| **setWaveform**| PlayerErrors|`SoundProps` sound<br/>`WaveForm` newWaveform| Set a new waveform for the [sound].|
-| **setWaveformScale**| PlayerErrors|`SoundProps` sound<br/>`double` newScale| Set a new scale for the [sound] (only if [superWave] is true).|
-| **setWaveformDetune**| PlayerErrors|`SoundProps` sound<br/>`double` newDetune| Set a new detune for the [sound] (only if [superWave] is true).|
-| **setWaveformFreq**| PlayerErrors|`SoundProps` sound<br/>`double` newFreq| Set a new frequency for the [sound].|
-| **setWaveformSuperWave**| PlayerErrors|`SoundProps` sound<br/>`bool` superwave| Set to compute superwave for the [sound].|
+| Function| Returns                                    | Params                                                                          | Description|
+|---------|--------------------------------------------|---------------------------------------------------------------------------------|------------|
+| **loadWaveform**| ({PlayerErrors error, AudioSource? sound}) | `WaveForm` waveform<br/>`bool` superWave<br/>`double` scale<br/>`double` detune | Load a new sound to be played.|
+| **setWaveform**| PlayerErrors                               | `AudioSource` sound<br/>`WaveForm` newWaveform                                  | Set a new waveform for the [sound].|
+| **setWaveformScale**| PlayerErrors                               | `SoundPropsAudioSource` sound<br/>`double` newScale                             | Set a new scale for the [sound] (only if [superWave] is true).|
+| **setWaveformDetune**| PlayerErrors                               | `SoundPropsAudioSource` sound<br/>`double` newDetune                            | Set a new detune for the [sound] (only if [superWave] is true).|
+| **setWaveformFreq**| PlayerErrors                               | `SoundPropsAudioSource` sound<br/>`double` newFreq                              | Set a new frequency for the [sound].|
+| **setWaveformSuperWave**| PlayerErrors                               | `SoundPropsAudioSource` sound<br/>`bool` superwave                              | Set to compute superwave for the [sound].|
 
 **enum WaveForm**
 | Name| Description|
@@ -209,7 +209,7 @@ The `AudioIsolate` instance has the duty of receiving commands and sending them 
 
 #### Audio FXs, faders and oscillators methods
 These methods add audio effects to sounds. 
-Faders and oscillators are binded to sound handles, so they need [SoundProps.handle] as first parameter. 
+Faders and oscillators are binded to sound handles, so they need [AudioSource.handle] as first parameter. 
 Audio FXs like *echo*, *freeverb*, *bassboost* etc, are working on the output, so they can set anytime while playing something.
 
 | Function| Returns| Params| Description|
@@ -293,7 +293,7 @@ The `PlayerErrors` enum:
 *AudioIsolate()* has a `StreamController` which can be used, for now, only to know when a sound handle reached the end:
 ```
 StreamSubscription<StreamSoundEvent>? _subscription;
-void listedToEndPlaying(SoundProps sound) {
+void listedToEndPlaying(AudioSource sound) {
   _subscription = sound!.soundEvents.stream.listen(
     (event) {
       /// Here the [event.handle] of [sound] has naturally finished

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,7 +4,6 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_soloud/flutter_soloud.dart';
-import 'package:flutter_soloud_example/controls.dart';
 import 'package:flutter_soloud_example/page_3d_audio.dart';
 import 'package:flutter_soloud_example/page_hello_flutter.dart';
 import 'package:flutter_soloud_example/page_multi_track.dart';

--- a/example/lib/main_wav_stream.dart
+++ b/example/lib/main_wav_stream.dart
@@ -57,7 +57,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  List<SoundProps> sounds = [];
+  List<AudioSource> sounds = [];
   bool isStarted = false;
   Duration minLength = const Duration(days: 99);
   ValueNotifier<Duration> seekPos = ValueNotifier(Duration.zero);
@@ -170,7 +170,7 @@ class SoundRow extends StatefulWidget {
     required this.soundProps,
     super.key,
   });
-  final SoundProps soundProps;
+  final AudioSource soundProps;
 
   @override
   State<SoundRow> createState() => _SoundRowState();

--- a/example/lib/page_3d_audio.dart
+++ b/example/lib/page_3d_audio.dart
@@ -15,7 +15,7 @@ class Page3DAudio extends StatefulWidget {
 class _Page3DAudioState extends State<Page3DAudio> {
   static final Logger _log = Logger('_Page3DAudioState');
 
-  SoundProps? currentSound;
+  AudioSource? currentSound;
   bool spinAround = false;
 
   @override
@@ -129,7 +129,7 @@ class Audio3DWidget extends StatefulWidget {
   });
 
   final bool spinAround;
-  final SoundProps? sound;
+  final AudioSource? sound;
   final double width;
   final double height;
 

--- a/example/lib/page_hello_flutter.dart
+++ b/example/lib/page_hello_flutter.dart
@@ -20,7 +20,7 @@ class PageHelloFlutterSoLoud extends StatefulWidget {
 class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
   static final Logger _log = Logger('_PageHelloFlutterSoLoudState');
 
-  SoundProps? currentSound;
+  AudioSource? currentSound;
 
   @override
   Widget build(BuildContext context) {
@@ -94,7 +94,7 @@ class _PageHelloFlutterSoLoudState extends State<PageHelloFlutterSoLoud> {
     }
 
     /// load the audio file
-    final SoundProps newSound;
+    final AudioSource newSound;
     try {
       newSound = await SoLoud.instance.loadFile(file);
     } catch (e) {

--- a/example/lib/page_multi_track.dart
+++ b/example/lib/page_multi_track.dart
@@ -16,8 +16,6 @@ class PageMultiTrack extends StatefulWidget {
 }
 
 class _PageMultiTrackState extends State<PageMultiTrack> {
-  static final Logger _log = Logger('_PageMultiTrackState');
-
   final _looping = ValueNotifier<bool>(false);
   final _loopingStartAt = ValueNotifier<double>(0);
   final _playSoundController = PlaySoundController();
@@ -136,7 +134,7 @@ class _PlaySoundWidgetState extends State<PlaySoundWidget> {
   final Map<SoundHandle, ValueNotifier<bool>> isPaused = {};
   final Map<SoundHandle, ValueNotifier<double>> soundPosition = {};
   StreamSubscription<StreamSoundEvent>? _subscription;
-  SoundProps? sound;
+  AudioSource? sound;
   bool _looping = false;
   double _loopingStartAt = 0;
 
@@ -179,7 +177,7 @@ class _PlaySoundWidgetState extends State<PlaySoundWidget> {
   Future<bool> loadAsset() async {
     final path = (await getAssetFile(widget.assetsAudio)).path;
 
-    final SoundProps? newSound;
+    final AudioSource? newSound;
     try {
       newSound = await SoLoud.instance.loadFile(path);
     } catch (e) {

--- a/example/lib/page_visualizer.dart
+++ b/example/lib/page_visualizer.dart
@@ -51,7 +51,7 @@ class _PageVisualizerState extends State<PageVisualizer> {
   final ValueNotifier<double> soundLength = ValueNotifier(0);
   final ValueNotifier<double> soundPosition = ValueNotifier(0);
   Timer? timer;
-  SoundProps? currentSound;
+  AudioSource? currentSound;
   FftController visualizerController = FftController();
 
   @override

--- a/example/lib/page_waveform.dart
+++ b/example/lib/page_waveform.dart
@@ -7,7 +7,6 @@ import 'package:flutter_soloud_example/waveform/filter_fx.dart';
 import 'package:flutter_soloud_example/waveform/keyboard_widget.dart';
 import 'package:flutter_soloud_example/waveform/knobs_groups.dart';
 import 'package:flutter_soloud_example/waveform/text_slider.dart';
-import 'package:logging/logging.dart';
 import 'package:star_menu/star_menu.dart';
 
 /// Example to demostrate how waveforms work with a keyboard
@@ -20,8 +19,6 @@ class PageWaveform extends StatefulWidget {
 }
 
 class _PageWaveformState extends State<PageWaveform> {
-  static final Logger _log = Logger('_PageWaveformState');
-
   ValueNotifier<double> scale = ValueNotifier(0.25);
   ValueNotifier<double> detune = ValueNotifier(1);
   ValueNotifier<WaveForm> waveForm = ValueNotifier(WaveForm.fSquare);
@@ -34,8 +31,8 @@ class _PageWaveformState extends State<PageWaveform> {
   double oscillateVol = 0;
   double oscillatePan = 0;
   double oscillateSpeed = 0;
-  List<SoundProps> notes = [];
-  SoundProps? sound;
+  List<AudioSource> notes = [];
+  AudioSource? sound;
   bool canBuild = false;
 
   @override

--- a/example/lib/waveform/keyboard_widget.dart
+++ b/example/lib/waveform/keyboard_widget.dart
@@ -24,7 +24,7 @@ class KeyboardWidget extends StatefulWidget {
   final Duration oscillateVolume;
   final Duration oscillatePan;
   final Duration oscillateSpeed;
-  final List<SoundProps> notes;
+  final List<AudioSource> notes;
 
   @override
   State<KeyboardWidget> createState() => _KeyboardWidgetState();

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -76,7 +76,7 @@ void main() async {
 }
 
 String output = '';
-SoundProps? currentSound;
+AudioSource? currentSound;
 
 Future<void> delay(int ms) async {
   await Future.delayed(Duration(milliseconds: ms), () {});

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -9,6 +9,27 @@
 version: 1
 
 transforms:
+  # AudioSource.handle => AudioSource.handles
+  - title: "Rename to 'handles'"
+    date: 2024-03-11
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      getter: 'handle'
+      inClass: 'AudioSource'
+    changes:
+      - kind: 'rename'
+        newName: 'handles'
+
+  # SoundProps => AudioSource
+  - title: "Rename to 'AudioSource'"
+    date: 2024-03-18
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      class: 'SoundProps'
+    changes:
+      - kind: 'rename'
+        newName: 'AudioSource'
+
   # SoLoud.setFxParams => SoLoud.setFilterParameter
   - title: "Rename to 'setFilterParameter()'"
     date: 2024-03-15

--- a/lib/flutter_soloud.dart
+++ b/lib/flutter_soloud.dart
@@ -2,6 +2,7 @@
 ///
 library flutter_soloud;
 
+export 'src/audio_source.dart';
 export 'src/enums.dart' hide PlayerErrors;
 export 'src/exceptions/exceptions.dart';
 export 'src/filter_params.dart';

--- a/lib/src/audio_isolate.dart
+++ b/lib/src/audio_isolate.dart
@@ -87,7 +87,7 @@ void audioIsolate(SendPort isolateToMainStream) {
   final soLoudController = SoLoudController();
 
   /// the active sounds
-  final activeSounds = <SoundProps>[];
+  final activeSounds = <AudioSource>[];
   var loopRunning = false;
 
   /// Tell the main isolate how to communicate with this isolate
@@ -130,9 +130,9 @@ void audioIsolate(SendPort isolateToMainStream) {
           args.mode,
         );
         // add the new sound handler to the list
-        SoundProps? newSound;
+        AudioSource? newSound;
         if (ret.error == PlayerErrors.noError) {
-          newSound = SoundProps(ret.soundHash);
+          newSound = AudioSource(ret.soundHash);
           activeSounds.add(newSound);
         } else if (ret.error == PlayerErrors.fileAlreadyLoaded) {
           /// the file is already loaded.
@@ -142,7 +142,7 @@ void audioIsolate(SendPort isolateToMainStream) {
             (s) => s.soundHash == ret.soundHash,
             orElse: () {
               isAlreadyThere = false;
-              return SoundProps(ret.soundHash);
+              return AudioSource(ret.soundHash);
             },
           );
           if (!isAlreadyThere) activeSounds.add(newSound);
@@ -163,9 +163,9 @@ void audioIsolate(SendPort isolateToMainStream) {
           args.detune,
         );
         // add the new sound handler to the list
-        SoundProps? newSound;
+        AudioSource? newSound;
         if (ret.error == PlayerErrors.noError) {
-          newSound = SoundProps(ret.soundHash);
+          newSound = AudioSource(ret.soundHash);
           activeSounds.add(newSound);
         } else if (ret.error == PlayerErrors.fileAlreadyLoaded) {
           /// the file is already loaded.
@@ -175,7 +175,7 @@ void audioIsolate(SendPort isolateToMainStream) {
             (s) => s.soundHash == ret.soundHash,
             orElse: () {
               isAlreadyThere = false;
-              return SoundProps(ret.soundHash);
+              return AudioSource(ret.soundHash);
             },
           );
           if (!isAlreadyThere) activeSounds.add(newSound);
@@ -190,7 +190,7 @@ void audioIsolate(SendPort isolateToMainStream) {
       case MessageEvents.speechText:
         final args = event['args']! as ArgsSpeechText;
         final ret = soLoudController.soLoudFFI.speechText(args.textToSpeech);
-        final newSound = SoundProps(SoundHash.random());
+        final newSound = AudioSource(SoundHash.random());
         newSound.handlesInternal.add(ret.handle);
         if (ret.error == PlayerErrors.noError) {
           // Add the new sound to the list

--- a/lib/src/audio_isolate.dart
+++ b/lib/src/audio_isolate.dart
@@ -5,8 +5,8 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_soloud/src/audio_source.dart';
 import 'package:flutter_soloud/src/enums.dart';
-import 'package:flutter_soloud/src/soloud.dart';
 import 'package:flutter_soloud/src/soloud_controller.dart';
 import 'package:flutter_soloud/src/sound_handle.dart';
 import 'package:flutter_soloud/src/sound_hash.dart';

--- a/lib/src/audio_source.dart
+++ b/lib/src/audio_source.dart
@@ -9,36 +9,48 @@ import 'package:meta/meta.dart';
 @Deprecated('Use SoundEventType instead')
 typedef SoundEvent = SoundEventType;
 
+/// A deprecated alias for [AudioSource].
+@Deprecated("Use 'AudioSource' instead")
+typedef SoundProps = AudioSource;
+
 /// the type sent back to the user when a sound event occurs
 typedef StreamSoundEvent = ({
   SoundEventType event,
-  SoundProps sound,
+  AudioSource sound,
   SoundHandle handle,
 });
 
-/// sound event types
-enum SoundEventType {
-  /// handle reached the end of playback
-  handleIsNoMoreValid,
-
-  /// the sound has been disposed
-  soundDisposed,
-}
-
-class SoundProps {
-  ///
-  SoundProps(this.soundHash);
+/// A representation of an audio source: something that can be played.
+///
+/// Audio sources cannot be instantiated directly. The need to be loaded
+/// (via something like `SoLoud.loadFile()`, for example).
+/// Then they can be played once or several times.
+/// Finally, the need to be disposed with something like
+/// `SoLoud.disposeSound()` or `SoLoud.disposeAllSounds()`.
+///
+/// Audio sources are uniquely identified by their [soundHash], which is
+/// what you pass to methods such as `SoLoud.play()`.
+///
+/// Playing a sound in this way creates a new sound _instance_. There can
+/// be several instances of one audio source playing simultaneously.
+/// You can access the currently playing instances' handles via [handles].
+///
+/// You can listen to the broadcast stream of [soundEvents].
+class AudioSource {
+  /// Constructs an instance of [AudioSource].
+  @internal
+  AudioSource(this.soundHash);
 
   /// The hash uniquely identifying this loaded sound.
   final SoundHash soundHash;
 
   /// The handles of currently playing instances of this sound.
   ///
-  /// A sound (expressed as [SoundProps]) can be loaded once, but then
+  /// A sound (expressed as [AudioSource]) can be loaded once, but then
   /// played multiple times. It's even possible to play several instances
   /// of the sound simultaneously.
   ///
-  /// Each time you [SoLoud.play] a sound, you get back a [SoundHandle],
+  /// Each time you `SoLoud.play()` a sound, you get back a [SoundHandle],
   /// and that same handle will be added to this [handles] set.
   /// When the sound finishes playing, its handle will be removed from this set.
   ///
@@ -72,4 +84,13 @@ class SoundProps {
   String toString() {
     return 'soundHash: $soundHash has ${handles.length} active handles';
   }
+}
+
+/// sound event types
+enum SoundEventType {
+  /// handle reached the end of playback
+  handleIsNoMoreValid,
+
+  /// the sound has been disposed
+  soundDisposed,
 }

--- a/lib/src/audio_source.dart
+++ b/lib/src/audio_source.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter_soloud/src/sound_handle.dart';
+import 'package:flutter_soloud/src/sound_hash.dart';
+import 'package:meta/meta.dart';
+
+/// Deprecated alias to [SoundEventType].
+@Deprecated('Use SoundEventType instead')
+typedef SoundEvent = SoundEventType;
+
+/// the type sent back to the user when a sound event occurs
+typedef StreamSoundEvent = ({
+  SoundEventType event,
+  SoundProps sound,
+  SoundHandle handle,
+});
+
+/// sound event types
+enum SoundEventType {
+  /// handle reached the end of playback
+  handleIsNoMoreValid,
+
+  /// the sound has been disposed
+  soundDisposed,
+}
+
+class SoundProps {
+  ///
+  SoundProps(this.soundHash);
+
+  /// The hash uniquely identifying this loaded sound.
+  final SoundHash soundHash;
+
+  /// The handles of currently playing instances of this sound.
+  ///
+  /// A sound (expressed as [SoundProps]) can be loaded once, but then
+  /// played multiple times. It's even possible to play several instances
+  /// of the sound simultaneously.
+  ///
+  /// Each time you [SoLoud.play] a sound, you get back a [SoundHandle],
+  /// and that same handle will be added to this [handles] set.
+  /// When the sound finishes playing, its handle will be removed from this set.
+  ///
+  /// This set is unmodifiable.
+  late final UnmodifiableSetView<SoundHandle> handles =
+      UnmodifiableSetView(handlesInternal);
+
+  /// The [internal] backing of [handles].
+  ///
+  /// Use [handles].
+  @internal
+  final Set<SoundHandle> handlesInternal = {};
+
+  ///
+  // TODO(marco): make marker keys time able to trigger an event
+  final List<double> keys = [];
+
+  /// Backing controller for [soundEvents].
+  @internal
+  final StreamController<StreamSoundEvent> soundEventsController =
+      StreamController.broadcast();
+
+  /// This getter is [deprecated] and will be removed. Use [handles] instead.
+  @Deprecated("Use 'handles' instead")
+  UnmodifiableSetView<SoundHandle> get handle => handles;
+
+  /// the user can listen ie when a sound ends or key events (TODO)
+  Stream<StreamSoundEvent> get soundEvents => soundEventsController.stream;
+
+  @override
+  String toString() {
+    return 'soundHash: $soundHash has ${handles.length} active handles';
+  }
+}

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -378,9 +378,9 @@ class FlutterSoLoudFfi {
   /// [looping] whether to start the sound in looping state.
   /// [loopingStartAt] If looping is enabled, the loop point is, by default,
   /// the start of the stream. The loop start point can be set with this
-  /// parameter, and current loop point can be queried with [getLoopingPoint]
-  /// and changed by [setLoopingPoint].
-  /// Return the error if any and a new [newHandle] of this sound
+  /// parameter, and current loop point can be queried with `getLoopingPoint()`
+  /// and changed by `setLoopingPoint()`.
+  /// Return the error if any and a new `newHandle` of this sound
   ({PlayerErrors error, SoundHandle newHandle}) play(
     SoundHash soundHash, {
     double volume = 1,
@@ -1018,8 +1018,8 @@ class FlutterSoLoudFfi {
   /// [looping] whether to start the sound in looping state.
   /// [loopingStartAt] If looping is enabled, the loop point is, by default,
   /// the start of the stream. The loop start point can be set with this
-  /// parameter, and current loop point can be queried with [getLoopingPoint]
-  /// and changed by [setLoopingPoint].
+  /// parameter, and current loop point can be queried with `getLoopingPoint()`
+  /// and changed by `setLoopingPoint()`.
   /// Returns the handle of the sound, 0 if error
   ({PlayerErrors error, SoundHandle newHandle}) play3d(
     SoundHash soundHash,

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -430,14 +430,14 @@ class FlutterSoLoudFfi {
   ///
   /// [soundHash]
   void disposeSound(SoundHash soundHash) {
-    return _stopSound(soundHash.hash);
+    return _disposeSound(soundHash.hash);
   }
 
-  late final _stopSoundPtr =
+  late final _disposeSoundPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.UnsignedInt)>>(
     'disposeSound',
   );
-  late final _stopSound = _stopSoundPtr.asFunction<void Function(int)>();
+  late final _disposeSound = _disposeSoundPtr.asFunction<void Function(int)>();
 
   /// Dispose all sounds already loaded
   void disposeAllSound() {

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -234,10 +234,10 @@ interface class SoLoud {
   /// should be synchronized with each other
   ///
   /// Backing of [activeSounds].
-  final List<SoundProps> _activeSounds = [];
+  final List<AudioSource> _activeSounds = [];
 
   /// The sounds that are currently _playing_.
-  Iterable<SoundProps> get activeSounds => _activeSounds;
+  Iterable<AudioSource> get activeSounds => _activeSounds;
 
   /// Wait for the isolate to return after the event has been completed.
   /// The event must be recognized by [event] and [args] sent to
@@ -395,7 +395,7 @@ interface class SoLoud {
             orElse: () {
               _log.info(() => 'Received an event for sound with handle: '
                   "${data.handle} but such sound isn't among _activeSounds.");
-              return SoundProps(SoundHash.invalid());
+              return AudioSource(SoundHash.invalid());
             },
           );
 
@@ -696,10 +696,10 @@ interface class SoLoud {
   /// from the given file when needed (more CPU, less memory allocated).
   /// See the [seek] note problem when using [LoadMode] = `LoadMode.disk`.
   /// Default is `LoadMode.memory`.
-  /// Returns the new sound as [SoundProps].
+  /// Returns the new sound as [AudioSource].
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  Future<SoundProps> loadFile(
+  Future<AudioSource> loadFile(
     String completeFileName, {
     LoadMode mode = LoadMode.memory,
   }) async {
@@ -715,7 +715,7 @@ interface class SoLoud {
     final ret = (await _waitForEvent(
       MessageEvents.loadFile,
       (completeFileName: completeFileName, mode: mode),
-    )) as ({PlayerErrors error, SoundProps? sound});
+    )) as ({PlayerErrors error, AudioSource? sound});
 
     _logPlayerError(ret.error, from: 'loadFile() result');
     if (ret.error == PlayerErrors.noError) {
@@ -758,8 +758,8 @@ interface class SoLoud {
   /// creating the temporary file that the asset will be copied to.
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
   ///
-  /// Returns the new sound as [SoundProps].
-  Future<SoundProps> loadAsset(
+  /// Returns the new sound as [AudioSource].
+  Future<AudioSource> loadAsset(
     String key, {
     LoadMode mode = LoadMode.memory,
     AssetBundle? assetBundle,
@@ -793,8 +793,8 @@ interface class SoLoud {
   /// creating the temporary file that the asset will be copied to.
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
   ///
-  /// Returns the new sound as [SoundProps].
-  Future<SoundProps> loadUrl(
+  /// Returns the new sound as [AudioSource].
+  Future<AudioSource> loadUrl(
     String url, {
     LoadMode mode = LoadMode.memory,
     http.Client? httpClient,
@@ -817,8 +817,8 @@ interface class SoLoud {
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
   ///
-  /// Returns the new sound as [SoundProps].
-  Future<SoundProps> loadWaveform(
+  /// Returns the new sound as [AudioSource].
+  Future<AudioSource> loadWaveform(
     WaveForm waveform,
     bool superWave,
     double scale,
@@ -847,7 +847,7 @@ interface class SoLoud {
         scale: scale,
         detune: detune,
       ),
-    )) as ({PlayerErrors error, SoundProps? sound});
+    )) as ({PlayerErrors error, AudioSource? sound});
     if (ret.error == PlayerErrors.noError) {
       _activeSounds.add(ret.sound!);
       return ret.sound!;
@@ -862,7 +862,7 @@ interface class SoLoud {
   /// [newWaveform] the new waveform type.
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  void setWaveform(SoundProps sound, WaveForm newWaveform) {
+  void setWaveform(AudioSource sound, WaveForm newWaveform) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -875,7 +875,7 @@ interface class SoLoud {
   /// [newScale] the new scale.
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  void setWaveformScale(SoundProps sound, double newScale) {
+  void setWaveformScale(AudioSource sound, double newScale) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -888,7 +888,7 @@ interface class SoLoud {
   /// [newDetune] the new detune.
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  void setWaveformDetune(SoundProps sound, double newDetune) {
+  void setWaveformDetune(AudioSource sound, double newDetune) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -901,7 +901,7 @@ interface class SoLoud {
   /// [newFrequency] the new frequency.
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  void setWaveformFreq(SoundProps sound, double newFrequency) {
+  void setWaveformFreq(AudioSource sound, double newFrequency) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -914,7 +914,7 @@ interface class SoLoud {
   /// [superwave] whether this sound should be a super wave or not.
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  void setWaveformSuperWave(SoundProps sound, bool superwave) {
+  void setWaveformSuperWave(AudioSource sound, bool superwave) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -927,10 +927,10 @@ interface class SoLoud {
   /// Speech the given text.
   ///
   /// [textToSpeech] the text to be spoken.
-  /// Returns the new sound as [SoundProps].
+  /// Returns the new sound as [AudioSource].
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  Future<SoundProps> speechText(String textToSpeech) async {
+  Future<AudioSource> speechText(String textToSpeech) async {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -943,7 +943,7 @@ interface class SoLoud {
     final ret = (await _waitForEvent(
       MessageEvents.speechText,
       (textToSpeech: textToSpeech),
-    )) as ({PlayerErrors error, SoundProps sound});
+    )) as ({PlayerErrors error, AudioSource sound});
     _logPlayerError(ret.error, from: 'speechText() result');
     if (ret.error == PlayerErrors.noError) {
       _activeSounds.add(ret.sound);
@@ -962,7 +962,7 @@ interface class SoLoud {
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
   Future<SoundHandle> play(
-    SoundProps sound, {
+    AudioSource sound, {
     double volume = 1,
     double pan = 0,
     bool paused = false,
@@ -1114,7 +1114,7 @@ interface class SoLoud {
   /// [sound] the sound to clear.
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  Future<void> disposeSound(SoundProps sound) async {
+  Future<void> disposeSound(AudioSource sound) async {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -1243,7 +1243,7 @@ interface class SoLoud {
   /// [sound] the sound hash to get the length.
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
-  Duration getLength(SoundProps sound) {
+  Duration getLength(AudioSource sound) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -1837,7 +1837,7 @@ interface class SoLoud {
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
   Future<SoundHandle> play3d(
-    SoundProps sound,
+    AudioSource sound,
     double posX,
     double posY,
     double posZ, {

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -696,7 +696,7 @@ interface class SoLoud {
   /// Miniaudio audio backend
   /// sample rate 44100
   /// buffer 2048
-  /// TODO(marco): add initialization parameters
+  // TODO(marco): add initialization parameters
   Future<PlayerErrors> _initEngine() async {
     _log.finest('_initEngine() called');
     if (_isolate == null) {
@@ -1798,7 +1798,7 @@ interface class SoLoud {
     return ret.index;
   }
 
-  /// TODO(marco): add a method to rearrange filters order?
+  // TODO(marco): add a method to rearrange filters order?
 
   /// Get parameters names of the given filter.
   ///

--- a/lib/src/sound_hash.dart
+++ b/lib/src/sound_hash.dart
@@ -2,7 +2,7 @@ import 'dart:math';
 
 import 'package:meta/meta.dart';
 
-/// A hash of a `SoundProps` instance.
+/// A hash of an `AudioSource` instance.
 ///
 /// Each newly loaded sound gets a unique hash. This hash is then used
 /// to uniquely identify the loaded sound to SoLoud.

--- a/lib/src/tools/soloud_tools.dart
+++ b/lib/src/tools/soloud_tools.dart
@@ -112,7 +112,7 @@ class SoLoudTools {
         superwave: superwave,
       );
 
-  /// Returns a list of the 12 SoundProps (notes) of the given octave
+  /// Returns a list of the 12 [AudioSource] notes of the given octave
   ///
   /// [octave] usually from 0 to 4
   static Future<List<AudioSource>> createNotes({

--- a/lib/src/tools/soloud_tools.dart
+++ b/lib/src/tools/soloud_tools.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_soloud/src/audio_source.dart';
 import 'package:flutter_soloud/src/enums.dart';
 import 'package:flutter_soloud/src/soloud.dart';
 import 'package:flutter_soloud/src/utils/assets_manager.dart';

--- a/lib/src/tools/soloud_tools.dart
+++ b/lib/src/tools/soloud_tools.dart
@@ -23,7 +23,7 @@ class SoLoudTools {
 
   /// Loads an audio file from the assets folder.
   @Deprecated('Use SoLoud.loadAsset() instead')
-  static Future<SoundProps?> loadFromAssets(
+  static Future<AudioSource?> loadFromAssets(
     String path, {
     LoadMode mode = LoadMode.memory,
   }) async {
@@ -38,7 +38,7 @@ class SoLoudTools {
 
   /// Loads an audio file from the local file system.
   @Deprecated('Use SoLoud.loadFile() instead')
-  static Future<SoundProps?> loadFromFile(
+  static Future<AudioSource?> loadFromFile(
     String path, {
     LoadMode mode = LoadMode.memory,
   }) async {
@@ -53,7 +53,7 @@ class SoLoudTools {
 
   /// Fetches an audio file from a URL and loads it into the memory.
   @Deprecated('Use SoLoud.loadUrl() instead')
-  static Future<SoundProps?> loadFromUrl(
+  static Future<AudioSource?> loadFromUrl(
     String url, {
     LoadMode mode = LoadMode.memory,
   }) async {
@@ -87,7 +87,7 @@ class SoLoudTools {
   /// Let SoLoud try to load the file
   ///
   @Deprecated('Only used internally by deprecated methods')
-  static Future<SoundProps?> _finallyLoadFile(
+  static Future<AudioSource?> _finallyLoadFile(
     File file, {
     LoadMode mode = LoadMode.memory,
   }) async {
@@ -101,7 +101,7 @@ class SoLoudTools {
 
   /// Deprecated: Use [createNotes] instead.
   @Deprecated("Use 'createNotes' instead.")
-  static Future<List<SoundProps>> initSounds({
+  static Future<List<AudioSource>> initSounds({
     int octave = 3,
     WaveForm waveForm = WaveForm.sin,
     bool superwave = true,
@@ -115,14 +115,14 @@ class SoLoudTools {
   /// Returns a list of the 12 SoundProps (notes) of the given octave
   ///
   /// [octave] usually from 0 to 4
-  static Future<List<SoundProps>> createNotes({
+  static Future<List<AudioSource>> createNotes({
     int octave = 3,
     WaveForm waveForm = WaveForm.sin,
     bool superwave = true,
   }) async {
     assert(octave >= 0 && octave <= 4, '0 >= octave <= 4 is not true!');
     final startingFreq = 55.0 * (pow(2, (12 * octave) / 12));
-    final notes = <SoundProps>[];
+    final notes = <AudioSource>[];
     for (var index = 0; index < 12; index++) {
       final sound = await SoLoud.instance.loadWaveform(
         waveForm,

--- a/test_fixes/audio_source.dart
+++ b/test_fixes/audio_source.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
-  final sound = AudioSource(SoundHash.invalid());
-  print(sound.handles);
+  final SoundProps? sound;
 }

--- a/test_fixes/audio_source.dart.expect
+++ b/test_fixes/audio_source.dart.expect
@@ -1,6 +1,5 @@
 import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
-  final sound = AudioSource(SoundHash.invalid());
-  print(sound.handles);
+  final AudioSource? sound;
 }


### PR DESCRIPTION
## Description

- Renamed `SoundProps` to `AudioSource`. Quick fix available.
- Added `SoundProps` as a temporary alias of `AudioSource`, for easier migration.

Fixes #52.


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
