### PR TITLE
Add new `AudioSource.allInstancesFinished` stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,9 @@ to `2.0.0-pre.2` and beyond.
   This mimics the C++ API name.
   Quick fix available.
 - Renamed `SoundProps` to `AudioSource`. Quick fix available.
-- Added new `AudioSource.allInstancesFinished` stream. This can be used to
-  more easily await times when it's safe to dispose the sound. For example:
+- Added new (experimental) `AudioSource.allInstancesFinished` stream. 
+  This can be used to more easily await times when it's safe to dispose 
+  the sound. For example:
 
   ```dart
   final source = soloud.loadAsset('...');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ to `2.0.0-pre.2` and beyond.
   // (finished playing or were stopped with soloud.stop()).
   source.allInstancesFinished.first.then(
     // Dispose of the sound.
-    (_) => soloud.disposeSound(source))
+    (_) => soloud.disposeSound(source)
   );
   soloud.play(source);
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ to `2.0.0-pre.2` and beyond.
   This mimics the C++ API name.
   Quick fix available.
 - Renamed `SoundProps` to `AudioSource`. Quick fix available.
+- Added new `AudioSource.allInstancesFinished` stream. This can be used to
+  more easily await times when it's safe to dispose the sound. For example:
+
+  ```dart
+  final source = soloud.loadAsset('...');
+  // Wait for the first time all the instances of the sound are finished
+  // (finished playing or were stopped with soloud.stop()).
+  source.allInstancesFinished.first.then(
+    // Dispose of the sound.
+    (_) => soloud.disposeSound(source))
+  );
+  soloud.play(source);
+  ```
 
 #### 2.0.0-pre.1 (12 Mar 2024)
 - added `looping` and `loopingStartAt` properties to `SoLoud.play()` and `SoLoud.play3d()`.

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -232,24 +232,25 @@ Future<void> test3() async {
   );
 
   for (var i = 2; i < 10; i++) {
+    const volume = 0.2;
     final d = (sin(i / 6.28) * 400).toInt();
-    await SoLoud.instance.play(notes[7]);
+    await SoLoud.instance.play(notes[7], volume: volume);
     await delay(500 - d);
     await SoLoud.instance.stop(notes[7].handles.first);
 
-    await SoLoud.instance.play(notes[10]);
+    await SoLoud.instance.play(notes[10], volume: volume);
     await delay(550 - d);
     await SoLoud.instance.stop(notes[10].handles.first);
 
-    await SoLoud.instance.play(notes[7]);
+    await SoLoud.instance.play(notes[7], volume: volume);
     await delay(500 - d);
     await SoLoud.instance.stop(notes[7].handles.first);
 
-    await SoLoud.instance.play(notes[0]);
+    await SoLoud.instance.play(notes[0], volume: volume);
     await delay(500 - d);
     await SoLoud.instance.stop(notes[0].handles.first);
 
-    await SoLoud.instance.play(notes[4]);
+    await SoLoud.instance.play(notes[4], volume: volume);
     await delay(800 - d);
     await SoLoud.instance.stop(notes[4].handles.first);
 

--- a/lib/src/audio_source.dart
+++ b/lib/src/audio_source.dart
@@ -58,9 +58,12 @@ class AudioSource {
   late final UnmodifiableSetView<SoundHandle> handles =
       UnmodifiableSetView(handlesInternal);
 
-  /// The [internal] backing of [handles].
+  /// The [internal] backing of [handles]/ Use [handles] from outside
+  /// the package.
   ///
-  /// Use [handles].
+  /// If you are removing a handle from this set, remember to check whether
+  /// this was the last one (`handles.isEmpty`). If so, you should
+  /// add an event to [allInstancesFinishedController].
   @internal
   final Set<SoundHandle> handlesInternal = {};
 
@@ -79,6 +82,31 @@ class AudioSource {
 
   /// the user can listen ie when a sound ends or key events (TODO)
   Stream<StreamSoundEvent> get soundEvents => soundEventsController.stream;
+
+  /// Backing controller for [allInstancesFinished].
+  @internal
+  final StreamController<void> allInstancesFinishedController =
+      StreamController.broadcast();
+
+  /// A stream that adds an event every time the number of concurrently
+  /// playing instances of this [AudioSource] reaches zero.
+  ///
+  /// This can be used to await times when an audio source can be safely
+  /// disposed. For example:
+  ///
+  /// ```dart
+  /// final source = soloud.loadAsset('...');
+  /// // Wait for the first time all the instances of the sound are finished
+  /// // (finished playing or were stopped with soloud.stop()).
+  /// source.allInstancesFinished.first.then(
+  ///   // Dispose of the sound.
+  ///   (_) => soloud.disposeSound(source))
+  /// );
+  /// soloud.play(source);
+  /// ```
+  @experimental
+  Stream<void> get allInstancesFinished =>
+      allInstancesFinishedController.stream;
 
   @override
   String toString() {

--- a/lib/src/audio_source.dart
+++ b/lib/src/audio_source.dart
@@ -73,7 +73,7 @@ class AudioSource {
 
   /// Backing controller for [soundEvents].
   @internal
-  final StreamController<StreamSoundEvent> soundEventsController =
+  late final StreamController<StreamSoundEvent> soundEventsController =
       StreamController.broadcast();
 
   /// This getter is [deprecated] and will be removed. Use [handles] instead.
@@ -85,7 +85,7 @@ class AudioSource {
 
   /// Backing controller for [allInstancesFinished].
   @internal
-  final StreamController<void> allInstancesFinishedController =
+  late final StreamController<void> allInstancesFinishedController =
       StreamController.broadcast();
 
   /// A stream that adds an event every time the number of concurrently

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 import 'dart:ffi' as ffi;
 import 'dart:isolate';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_soloud/src/audio_isolate.dart';
@@ -417,6 +416,10 @@ interface class SoLoud {
                   return handle == data.handle;
                 },
               );
+              if (sound.handles.isEmpty) {
+                // All instances of the sound have finished.
+                sound.allInstancesFinishedController.add(null);
+              }
             }
           }
         } else {
@@ -562,15 +565,16 @@ interface class SoLoud {
 
   /// Stops the engine and disposes of all resources, including sounds
   /// and the audio isolate in an synchronous way.
-  /// 
+  ///
   /// This method is meant to be called when exiting the app. For example
   /// within the `dispose()` of the uppermost widget in the tree
   /// or inside [AppLifecycleListener.onExitRequested].
-  /// 
+  ///
   /// During the normal app life cycle and if you want to shutdown the player,
   /// please use [shutdown] which safer and it is meant to throw errors.
   void deinit() {
     _log.finest('deinit() called');
+
     /// check if we are in the middle of an initialization.
     if (_initializeCompleter != null) {
       _log.warning('deinit() called while already initializing.');
@@ -1146,6 +1150,9 @@ interface class SoLoud {
     /// find a sound with this handle and remove that handle from the list
     for (final sound in _activeSounds) {
       sound.handlesInternal.removeWhere((element) => element == handle);
+      if (sound.handles.isEmpty) {
+        sound.allInstancesFinishedController.add(null);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

- Added new (experimental) `AudioSource.allInstancesFinished` stream. 
  This can be used to more easily await times when it's safe to dispose 
  the sound. For example:

  ```dart
  final source = soloud.loadAsset('...');
  // Wait for the first time all the instances of the sound are finished
  // (finished playing or were stopped with soloud.stop()).
  source.allInstancesFinished.first.then(
    // Dispose of the sound.
    (_) => soloud.disposeSound(source))
  );
  soloud.play(source);
  ```

I'm not sure about this. It looks convenient to me in my current use case, but it bloats the API by another stream.

The main use case is for when there are sounds that should be disposed after playing them once (such as music tracks) and only loaded again when they're needed the next time. With the current API, this would look something like this:

```dart
    late final StreamSubscription<StreamSoundEvent> subscription;
    subscription = musicSource.soundEvents.listen((event) {
      if (event.event == SoundEventType.handleIsNoMoreValid &&
          musicSource.handles.isEmpty) {
        _soloud!.disposeSound(musicSource);
        subscription.cancel();
      }
    });
```

The new code:

```dart
musicSource.allInstancesFinished.first.then((_) => soloud.disposeSound(musicSource));
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
