### PR TITLE
fix: asynchronous initialize-deinit bug

### DIFF
--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -37,29 +37,29 @@ void main() async {
     },
   );
 
-  // await runZonedGuarded(
-  //   () async => test3(),
-  //   (error, stack) {
-  //     stderr.writeln('TEST error: $error\nstack: $stack');
-  //     exitCode = 1;
-  //   },
-  // );
+  await runZonedGuarded(
+    () async => test3(),
+    (error, stack) {
+      stderr.writeln('TEST error: $error\nstack: $stack');
+      exitCode = 1;
+    },
+  );
 
-  // await runZonedGuarded(
-  //   () async => test1(),
-  //   (error, stack) {
-  //     stderr.writeln('TEST error: $error\nstack: $stack');
-  //     exitCode = 1;
-  //   },
-  // );
+  await runZonedGuarded(
+    () async => test1(),
+    (error, stack) {
+      stderr.writeln('TEST error: $error\nstack: $stack');
+      exitCode = 1;
+    },
+  );
 
-  // await runZonedGuarded(
-  //   () async => test2(),
-  //   (error, stack) {
-  //     stderr.writeln('TEST error: $error\nstack: $stack');
-  //     exitCode = 1;
-  //   },
-  // );
+  await runZonedGuarded(
+    () async => test2(),
+    (error, stack) {
+      stderr.writeln('TEST error: $error\nstack: $stack');
+      exitCode = 1;
+    },
+  );
 
   stdout.write('\n\n\n---\n\n\n');
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -23,8 +23,9 @@ Player::~Player()
 
 PlayerErrors Player::init()
 {
-    if (mInited)
-        dispose();
+    if (mInited) dispose();
+    
+    std::lock_guard<std::mutex> guard(init_deinit_mutex);
 
     // initialize SoLoud.
     SoLoud::result result = soloud.init(
@@ -41,6 +42,7 @@ PlayerErrors Player::init()
 
 void Player::dispose()
 {
+    std::lock_guard<std::mutex> guard(init_deinit_mutex);
     // Clean up SoLoud
     soloud.deinit();
     mInited = false;

--- a/src/player.h
+++ b/src/player.h
@@ -477,6 +477,9 @@ public:
 
     /// Filters
     Filters mFilters;
+
+private:
+    std::mutex init_deinit_mutex;
 };
 
 #endif // PLAYER_H


### PR DESCRIPTION
## Description

Fix for #56
Doing some more testing on the `deinit()`, the bug was seen in `test4()` when trying to use unawaited `initialize()` and suddenly `deinit()`. Not happening with `await initialize()`. This caused a failed test.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
