### PR TITLE
added get and setProtectVoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - added `getVoiceCount()` to get the number of voices the application has told SoLoud to play.
 - added `getMaxActiveVoiceCount()` to get the current maximum active voice count.
 - added `setMaxActiveVoiceCount()` to set the current maximum active voice count.
+- added `setProtectVoice()` and `getProtectVoice()` to get/set the protect voice flag.
 
 #### 2.0.0-pre.2 (14 Mar 2024)
 

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -1436,30 +1436,35 @@ interface class SoLoud {
     return SoLoudController().soLoudFFI.getVoiceCount();
   }
 
-  // /// Get a sound's protection state.
-  // bool getProtectVoice(int handle) {
-  //   if (!isInitialized) {
-  //     throw const SoLoudNotInitializedException();
-  //   }
-  //   return SoLoudController().soLoudFFI.getProtectVoice(handle);
-  // }
+  /// Get a sound's protection state.
+  bool getProtectVoice(int handle) {
+    if (!isInitialized) {
+      throw const SoLoudNotInitializedException();
+    }
+    return SoLoudController().soLoudFFI.getProtectVoice(handle);
+  }
 
-  // /// Set a sound's protection state.
-  // ///
-  // /// Normally, if you try to play more sounds than there are voices,
-  // /// SoLoud will kill off the oldest playing sound to make room.
-  // /// This will most likely be your background music. This can be worked
-  // /// around by protecting the sound.
-  // /// If all voices are protected, the result will be undefined.
-  // ///
-  // /// [handle]  handle to check.
-  // /// [protect] whether to protect or not.
-  // void setProtectVoice(int handle, bool protect) {
-  //   if (!isInitialized) {
-  //     throw const SoLoudNotInitializedException();
-  //   }
-  //   SoLoudController().soLoudFFI.setProtectVoice(handle, protect);
-  // }
+  /// Set a sound's protection state.
+  ///
+  /// Normally, if you try to play more sounds than there are voices,
+  /// SoLoud will kill off the oldest playing sound to make room.
+  /// This will most likely be your background music. This can be worked
+  /// around by protecting the sound.
+  /// If all voices are protected, the result will be undefined.
+  /// The number of protected entries is inclusive in the 
+  /// max number active voice count [getMaxActiveVoiceCount]. 
+  /// For example when having 16 max active voice count set to 16, and
+  /// you want to play 20 other sounds, the protected voice will still play
+  /// but you will hear only 15 of the other 20.
+  ///
+  /// [handle]  handle to check.
+  /// [protect] whether to protect or not.
+  void setProtectVoice(int handle, bool protect) {
+    if (!isInitialized) {
+      throw const SoLoudNotInitializedException();
+    }
+    SoLoudController().soLoudFFI.setProtectVoice(handle, protect);
+  }
 
   /// Get the current maximum active voice count.
   int getMaxActiveVoiceCount() {

--- a/src/player.h
+++ b/src/player.h
@@ -289,6 +289,9 @@ public:
     /// If all voices are protected, the result will be undefined.
     /// @param handle  handle to check.
     /// @param protect whether to protect or not.
+    ///
+    /// NOTE: patched with
+    /// https://github.com/jarikomppa/soloud/issues/298
     void setProtectVoice(SoLoud::handle handle, bool protect);
 
     /// @brief Get the current maximum active voice count.


### PR DESCRIPTION
## Description

- added `getProtectVoice()`
- added `setProtectVoice()`

 `setProtectVoice()` now works #53. The number of protected entries is included in the maximum active voice count [getMaxActiveVoiceCount]. 
For example when having 16 max active voice count set to 16, and you want to play 20 other sounds, the protected voice will still play but you will hear only 15 of the other 20.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
