### PR TITLE
finer throws from addGlobalFilter()

### DIFF
--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -1058,11 +1058,18 @@ class FlutterSoLoudFfi {
 
   /// Add the filter [filterType].
   ///
-  /// [filterType] filter to add
-  /// Returns [PlayerErrors.noError] if no errors
+  /// [filterType] filter to add.
+  /// Returns:
+  /// [PlayerErrors.noError] if no errors
+  /// [PlayerErrors.filterNotFound] if the [filterType] does not exits
+  /// [PlayerErrors.filterAlreadyAdded] when trying to add an already 
+  ///     added filter
+  /// [PlayerErrors.maxNumberOfFiltersReached] when the maximum number of 
+  ///     filters has been reached (default is 8)
   ///
-  int addGlobalFilter(int filterType) {
-    return _addGlobalFilter(filterType);
+  PlayerErrors addGlobalFilter(int filterType) {
+    final e = _addGlobalFilter(filterType);
+    return PlayerErrors.values[e];
   }
 
   late final _addGlobalFilterPtr =

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -95,7 +95,13 @@ enum PlayerErrors {
   filterNotFound(12),
 
   /// asking for wave and FFT is not enabled
-  visualizationNotEnabled(13);
+  visualizationNotEnabled(13),
+
+  /// The maximum number of filters has been reached (default is 8).
+  maxNumberOfFiltersReached(14),
+
+  /// The filter has already been added.
+  filterAlreadyAdded(15);
 
   const PlayerErrors(this.value);
 
@@ -109,34 +115,38 @@ enum PlayerErrors {
       case PlayerErrors.noError:
         return 'No error';
       case PlayerErrors.invalidParameter:
-        return 'Some parameter is invalid';
+        return 'Some parameters are invalid!';
       case PlayerErrors.fileNotFound:
-        return 'File not found';
+        return 'File not found!';
       case PlayerErrors.fileLoadFailed:
-        return 'File found, but could not be loaded';
+        return 'File found, but could not be loaded!';
       case PlayerErrors.fileAlreadyLoaded:
-        return 'The sound file has already been loaded';
+        return 'The sound file has already been loaded!';
       case PlayerErrors.dllNotFound:
-        return 'DLL not found, or wrong DLL';
+        return 'DLL not found, or wrong DLL!';
       case PlayerErrors.outOfMemory:
-        return 'Out of memory';
+        return 'Out of memory!';
       case PlayerErrors.notImplemented:
-        return 'Feature not implemented';
+        return 'Feature not implemented!';
       case PlayerErrors.unknownError:
-        return 'Unknown error';
+        return 'Unknown error!';
       case PlayerErrors.nullPointer:
         return 'Capture null pointer error. Could happens when passing a non '
             'initialized pointer (with calloc()) to retrieve FFT or wave data. '
             'Or, setVisualization has not been enabled.';
       case PlayerErrors.soundHashNotFound:
-        return 'The sound with specified hash is not found';
+        return 'The sound with specified hash is not found!';
       case PlayerErrors.backendNotInited:
-        return 'Player not initialized';
+        return 'Player not initialized!';
       case PlayerErrors.filterNotFound:
-        return 'Filter not found';
+        return 'Filter not found!';
       case PlayerErrors.visualizationNotEnabled:
         return 'Asking for audio data is not enabled! Please use '
             '`setVisualizationEnabled(true);` to enable!';
+      case PlayerErrors.maxNumberOfFiltersReached:
+        return 'The maximum number of filters has been reached (default is 8)!';
+      case PlayerErrors.filterAlreadyAdded:
+        return 'Filter not found!';
     }
   }
 

--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -93,6 +93,10 @@ abstract class SoLoudCppException extends SoLoudException {
         return const SoLoudFilterNotFoundException();
       case PlayerErrors.visualizationNotEnabled:
         return const SoLoudVisualizationNotEnabledException();
+      case PlayerErrors.maxNumberOfFiltersReached:
+        return const SoLoudMaxFilterNumberReachedException();
+      case PlayerErrors.filterAlreadyAdded:
+        return const SoLoudFilterAlreadyAddedException();
     }
   }
 }

--- a/lib/src/exceptions/exceptions_from_cpp.dart
+++ b/lib/src/exceptions/exceptions_from_cpp.dart
@@ -129,3 +129,25 @@ class SoLoudVisualizationNotEnabledException extends SoLoudCppException {
       '(on the C++ side). '
       'Please use `setVisualizationEnabled(true);` to enable.';
 }
+
+/// An exception that is thrown when SoLoud (C++) cannot add another filter.
+/// The max number of concurrent filter is set to 8.
+class SoLoudMaxFilterNumberReachedException extends SoLoudCppException {
+  /// Creates a new [SoLoudMaxFilterNumberReachedException].
+  const SoLoudMaxFilterNumberReachedException([super.message]);
+
+  @override
+  String get description => 'Askind to add another filter, but no more then 8 '
+      'is allowed (on the C++ side).';
+}
+
+/// An exception that is thrown when SoLoud (C++) cannot add a filter 
+/// that has already been added.
+class SoLoudFilterAlreadyAddedException extends SoLoudCppException {
+  /// Creates a new [SoLoudFilterAlreadyAddedException].
+  const SoLoudFilterAlreadyAddedException([super.message]);
+
+  @override
+  String get description => 'Askind to add a filter that is already been added. '
+      'Only one of each type is allowed (on the C++ side).';
+}

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -1873,12 +1873,15 @@ interface class SoLoud {
   /// Add a filter to all sounds.
   /// [filterType] filter to add.
   ///
+  /// Throws [SoLoudMaxFilterNumberReachedException] when the max number of 
+  ///     concurrent filter is reached (default max filter is 8).
+  /// Throws [SoLoudFilterAlreadyAddedException] when trying to add a filter 
+  ///     that has already been added.
   void addGlobalFilter(FilterType filterType) {
-    final ret = SoLoudController().soLoudFFI.addGlobalFilter(filterType.index);
-    final error = PlayerErrors.values[ret];
-    if (error != PlayerErrors.noError) {
-      _log.severe(() => 'addGlobalFilter(): $error');
-      throw SoLoudCppException.fromPlayerError(error);
+    final e = SoLoudController().soLoudFFI.addGlobalFilter(filterType.index);
+    if (e != PlayerErrors.noError) {
+      _log.severe(() => 'addGlobalFilter(): $e');
+      throw SoLoudCppException.fromPlayerError(e);
     }
   }
 

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -799,9 +799,7 @@ extern "C"
     {
         if (!player.isInited())
             return backendNotInited;
-        if (!player.mFilters.addGlobalFilter(filterType))
-            return filterNotFound;
-        return noError;
+        return player.mFilters.addGlobalFilter(filterType);
     }
 
     /// Remove the filter [filterType].

--- a/src/enums.h
+++ b/src/enums.h
@@ -34,8 +34,12 @@ typedef enum PlayerErrors
     backendNotInited = 11,
     /// Filter not found
     filterNotFound = 12,
-    /// asking for wave and FFT is not enabled
+    /// Asking for wave and FFT is not enabled
     visualizationNotEnabled = 13,
+    /// The maximum number of filters has been reached (default is 8).
+    maxNumberOfFiltersReached = 14,
+    /// The filter has already been added.
+    filterAlreadyAdded = 15,
 } PlayerErrors_t;
 
 /// Possible capture errors

--- a/src/filters/filters.cpp
+++ b/src/filters/filters.cpp
@@ -121,15 +121,15 @@ std::vector<std::string> Filters::getFilterParamNames(FilterType filterType)
     return ret;
 }
 
-bool Filters::addGlobalFilter(FilterType filterType)
+PlayerErrors Filters::addGlobalFilter(FilterType filterType)
 {
     if (filters.size() >= FILTERS_PER_STREAM)
-        return false;
+        return maxNumberOfFiltersReached;
 
-    // Check if the new filter is already be here.
-    // Only one kind of filter allowed
+    // Check if the new filter is already here.
+    // Only one kind of filter allowed.
     if (isFilterActive(filterType) >= 0)
-        return false;
+        return filterAlreadyAdded;
 
     const unsigned int filtersSize = static_cast<unsigned int>(filters.size());
     switch (filterType)
@@ -189,9 +189,9 @@ bool Filters::addGlobalFilter(FilterType filterType)
         filters.push_back({filterType, static_cast<SoLoud::Filter *>(mFreeverbFilter.get())});
         break;
     default:
-        return false;
+        return filterNotFound;
     }
-    return true;
+    return noError;
 }
 /// TODO remove all filters FilterType.none
 bool Filters::removeGlobalFilter(FilterType filterType)

--- a/src/filters/filters.h
+++ b/src/filters/filters.h
@@ -16,6 +16,8 @@
 #include "soloud_robotizefilter.h"
 #include "soloud_freeverbfilter.h"
 
+#include "../enums.h"
+
 #include <vector>
 #include <string>
 #include <memory>
@@ -53,7 +55,7 @@ public:
     ~Filters();
 
     int isFilterActive(FilterType filter);
-    bool addGlobalFilter(FilterType filterType);
+    PlayerErrors addGlobalFilter(FilterType filterType);
     bool removeGlobalFilter(FilterType filterType);
     std::vector<std::string> getFilterParamNames(FilterType filterType);
     void setFxParams(FilterType filterType, int attributeId, float value);


### PR DESCRIPTION
## Description

Previously `addGlobalFilter()` only threw `SoLoudFilterNotFoundException` for any kind of errors (#62).
Added `SoLoudMaxFilterNumberReachedException` and `SoLoudFilterAlreadyAddedException`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
