### PR TITLE
Deprecate shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ to `2.0.0-pre.2` and beyond.
   );
   soloud.play(source);
   ```
+  
+- Deprecated `shutdown()`. Replaced with the synchronous `deinit()`.
+  Quick fix available.
+- Renamed `initialize()` to `init()`, in order to come closer to the original
+  C++ API, and also to have a symmetry (`init`/`deinit`).
+  Quick fix available.
 
 #### 2.0.0-pre.1 (12 Mar 2024)
 - added `looping` and `loopingStartAt` properties to `SoLoud.play()` and `SoLoud.play3d()`.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -55,7 +55,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
-    SoLoud.instance.shutdown();
+    SoLoud.instance.deinit();
     super.dispose();
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,7 +30,7 @@ void main() async {
   });
 
   /// Initialize the player
-  await SoLoud.instance.initialize().then(
+  await SoLoud.instance.init().then(
     (_) {
       Logger('main').info('player started');
       SoLoud.instance.setVisualizationEnabled(true);

--- a/example/lib/main_wav_stream.dart
+++ b/example/lib/main_wav_stream.dart
@@ -110,7 +110,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> stop() async {
-    await SoLoud.instance.shutdown();
+    SoLoud.instance.deinit();
     SoLoudCapture.instance.stopCapture();
     sounds.clear();
   }

--- a/example/lib/main_wav_stream.dart
+++ b/example/lib/main_wav_stream.dart
@@ -70,7 +70,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> start() async {
     try {
-      await SoLoud.instance.initialize();
+      await SoLoud.instance.init();
     } catch (e) {
       debugPrint('isolate starting error: $e');
       return;

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -212,7 +212,7 @@ Future<void> test4() async {
   for (var t = 100; t >= 0; t -= 5) {
     /// Initialize the player
     var error = '';
-    await SoLoud.instance.initialize().then(
+    await SoLoud.instance.init().then(
       (_) {},
       onError: (Object e) {
         e = 'TEST FAILED delay: $t. Player starting error: $e';
@@ -242,7 +242,7 @@ Future<void> test4() async {
   /// waiting for `initialize()` to finish
   for (var t = 50; t >= 0; t -= 2) {
     /// Initialize the player
-    unawaited(SoLoud.instance.initialize());
+    unawaited(SoLoud.instance.init());
 
     /// wait for [t] ms and deinit()
     await Future.delayed(Duration(milliseconds: t), () {});
@@ -258,7 +258,7 @@ Future<void> test4() async {
   }
 
   /// Try init-play-deinit and again init-play without disposing the sound
-  await SoLoud.instance.initialize();
+  await SoLoud.instance.init();
 
   await loadAsset();
   await SoLoud.instance.play(currentSound!);
@@ -273,7 +273,7 @@ Future<void> test4() async {
 
   /// Initialize again and check if the sound has been
   /// disposed correctly by `deinit()`
-  await SoLoud.instance.initialize();
+  await SoLoud.instance.init();
   assert(
     SoLoudController()
             .soLoudFFI
@@ -430,7 +430,7 @@ Future<void> test1() async {
 
 /// Common methods
 Future<void> initialize() async {
-  await SoLoud.instance.initialize();
+  await SoLoud.instance.init();
 }
 
 void dispose() {

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -152,7 +152,7 @@ Future<void> test6() async {
     'The protected song has been stopped!',
   );
 
-  await dispose();
+  dispose();
 }
 
 /// Test allInstancesFinished stream
@@ -203,7 +203,7 @@ Future<void> test5() async {
   assert(explosionDisposed, "Explosion sound wasn't disposed.");
   assert(songDisposed, "Song sound wasn't disposed.");
 
-  await dispose();
+  dispose();
 }
 
 /// Test synchronous `deinit()`
@@ -333,7 +333,7 @@ Future<void> test3() async {
     await delay(300);
   }
 
-  await dispose();
+  dispose();
 }
 
 /// Test play, pause, seek, position
@@ -365,7 +365,7 @@ Future<void> test2() async {
     assert(position == wantedPosition, 'getPosition() failed!');
   }
 
-  await dispose();
+  dispose();
 }
 
 /// Test start/stop isolate, load, play and events from sound
@@ -420,7 +420,7 @@ Future<void> test1() async {
   {
     /// Stop player and see in log:
     /// "@@@@@@@@@@@ SOUND EVENT: SoundEvent.soundDisposed .*"
-    await dispose();
+    dispose();
     assert(
       output == 'SoundEvent.soundDisposed',
       'Sound end playback event not triggered!',
@@ -433,9 +433,8 @@ Future<void> initialize() async {
   await SoLoud.instance.initialize();
 }
 
-Future<void> dispose() async {
-  final ret = await SoLoud.instance.shutdown();
-  assert(ret, 'dispose() failed!');
+void dispose() {
+  SoLoud.instance.deinit();
 }
 
 Future<void> loadAsset() async {

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -9,9 +9,20 @@
 version: 1
 
 transforms:
+  # SoLoud.initialize => SoLoud.init
+  - title: "Rename to 'init'"
+    date: 2024-03-20
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      method: 'initialize'
+      inClass: 'SoLoud'
+    changes:
+      - kind: 'rename'
+        newName: 'init'
+
   # SoLoud.shutdown => SoLoud.deinit
   - title: "Rename to 'deinit'"
-    date: 2024-03-11
+    date: 2024-03-20
     element:
       uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
       method: 'shutdown'

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -9,6 +9,17 @@
 version: 1
 
 transforms:
+  # SoLoud.shutdown => SoLoud.deinit
+  - title: "Rename to 'deinit'"
+    date: 2024-03-11
+    element:
+      uris: [ 'flutter_soloud.dart', 'package:flutter_soloud/flutter_soloud.dart' ]
+      method: 'shutdown'
+      inClass: 'SoLoud'
+    changes:
+      - kind: 'rename'
+        newName: 'deinit'
+
   # AudioSource.handle => AudioSource.handles
   - title: "Rename to 'handles'"
     date: 2024-03-11

--- a/lib/src/exceptions/exceptions_from_dart.dart
+++ b/lib/src/exceptions/exceptions_from_dart.dart
@@ -38,18 +38,14 @@ class SoLoudInitializationTimedOutException extends SoLoudDartException {
   String get description => 'The engine took too long to initialize.';
 }
 
-/// An exception that is thrown when the SoLoud engine fails to shutdown.
-/// This is not thrown during normal shutdown, but it _can_ be thrown if
-/// `initialize()` was called at a time of shutdown, and that shutdown failed.
-class ShutdownFailedException extends SoLoudDartException {
-  /// Creates a new [ShutdownFailedException].
-  const ShutdownFailedException([super.message]);
+/// An exception that is thrown when the SoLoud engine initialization
+/// is cut short by a call to `SoLoud.deinit()`.
+class SoLoudInitializationStoppedByDeinitException extends SoLoudDartException {
+  /// Creates a new [SoLoudInitializationStoppedByDeinitException].
+  const SoLoudInitializationStoppedByDeinitException([super.message]);
 
   @override
-  String get description => 'The engine failed to shut down. '
-      'This is not thrown during normal shutdown, but it _can_ be thrown if '
-      '`initialize()` was called at a time of a shutdown in progress, '
-      'and that shutdown failed.';
+  String get description => 'SoLoud.deinit() was called during initialization.';
 }
 
 /// An exception that is thrown when the temporary folder fails to be created

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -167,14 +167,14 @@ interface class SoLoud {
   /// or it had failed to initialize (`false`),
   /// or it was already shut down (`false`),
   /// or it is _being_ shut down (`false`),
-  /// or when there wasn't ever a call to [initialize] at all (`false`).
+  /// or when there wasn't ever a call to [init] at all (`false`).
   ///
   /// If the engine is in the middle of initializing, the future will complete
   /// when the initialization is done. It will be `true` if the initialization
   /// was successful, and `false` if it failed. The future will never throw.
   ///
-  /// It is _not_ needed to await this future after a call to [initialize].
-  /// The [initialize] method already returns a future, and it is the
+  /// It is _not_ needed to await this future after a call to [init].
+  /// The [init] method already returns a future, and it is the
   /// same future that this getter returns.
   ///
   /// ```dart
@@ -271,10 +271,18 @@ interface class SoLoud {
 
   /// Initializes the audio engine.
   ///
-  /// Use [initialize] instead. This method is simply an alias for [initialize]
+  /// Use [init] instead. This method is simply an alias for [init]
   /// for backwards compatibility. It will be removed in a future version.
-  @Deprecated('use initialize() instead')
-  Future<void> startIsolate() => initialize();
+  @Deprecated('use init() instead')
+  Future<void> startIsolate() => init();
+
+  /// Deprecated alias of [init].
+  @Deprecated("Use 'init()' instead")
+  Future<void> initialize({
+    Duration timeout = const Duration(seconds: 10),
+    bool automaticCleanup = false,
+  }) =>
+      init(timeout: timeout, automaticCleanup: automaticCleanup);
 
   /// Initializes the audio engine.
   ///
@@ -303,7 +311,7 @@ interface class SoLoud {
   /// The default is `false`.
   ///
   /// (This method was formerly called `startIsolate()`.)
-  Future<void> initialize({
+  Future<void> init({
     Duration timeout = const Duration(seconds: 10),
     bool automaticCleanup = false,
   }) async {
@@ -571,7 +579,7 @@ interface class SoLoud {
 
   /// A deprecated method that manually starts the engine.
   ///
-  /// Do not use. The engine is fully started with [initialize].
+  /// Do not use. The engine is fully started with [init].
   /// This method will be removed in a future version.
   @Deprecated('Use initialize() instead')
   Future<PlayerErrors> initEngine() => _initEngine();

--- a/test_fixes/soloud_disposal.dart
+++ b/test_fixes/soloud_disposal.dart
@@ -3,4 +3,5 @@ import 'package:flutter_soloud/flutter_soloud.dart';
 Future<void> main() async {
   await SoLoud.instance.stopIsolate();
   await SoLoud.instance.dispose();
+  await SoLoud.instance.shutdown();
 }

--- a/test_fixes/soloud_disposal.dart.expect
+++ b/test_fixes/soloud_disposal.dart.expect
@@ -1,6 +1,7 @@
 import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
-  await SoLoud.instance.shutdown();
-  await SoLoud.instance.shutdown();
+  SoLoud.instance.deinit();
+  SoLoud.instance.deinit();
+  SoLoud.instance.deinit();
 }

--- a/test_fixes/soloud_initialization.dart
+++ b/test_fixes/soloud_initialization.dart
@@ -3,4 +3,5 @@ import 'package:flutter_soloud/flutter_soloud.dart';
 Future<void> main() async {
   final soloud = SoLoud();
   await soloud.startIsolate();
+  await soloud.initialize();
 }

--- a/test_fixes/soloud_initialization.dart.expect
+++ b/test_fixes/soloud_initialization.dart.expect
@@ -2,5 +2,6 @@ import 'package:flutter_soloud/flutter_soloud.dart';
 
 Future<void> main() async {
   final soloud = SoLoud();
-  await soloud.initialize();
+  await soloud.init();
+  await soloud.init();
 }


### PR DESCRIPTION
## Description

- Deprecated `shutdown()`. Replaced with the synchronous `deinit()`.
  Quick fix available.
- Renamed `initialize()` to `init()`, in order to come closer to the original
  C++ API, and also to have a symmetry (`init`/`deinit`).
  Quick fix available.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
