### PR TITLE
Make the rest of handle/hash API type safe

### DIFF
--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -132,9 +132,9 @@ Future<void> test6() async {
 
   /// play 1 protected [song]
   final songHandle = await SoLoud.instance.play(song);
-  SoLoud.instance.setProtectVoice(songHandle.id, true);
+  SoLoud.instance.setProtectVoice(songHandle, true);
   assert(
-    SoLoud.instance.getProtectVoice(songHandle.id),
+    SoLoud.instance.getProtectVoice(songHandle),
     "setProtectVoice() didn't worked correctly",
   );
 
@@ -282,10 +282,7 @@ Future<void> test4() async {
     'getIsValidVoiceHandle(): sound not disposed by the engine',
   );
   assert(
-    SoLoudController()
-            .soLoudFFI
-            .countAudioSource(currentSound!.soundHash.hash) ==
-        0,
+    SoLoudController().soLoudFFI.countAudioSource(currentSound!.soundHash) == 0,
     'getCountAudioSource(): sound not disposed by the engine',
   );
   assert(

--- a/lib/src/bindings_player_ffi.dart
+++ b/lib/src/bindings_player_ffi.dart
@@ -120,8 +120,7 @@ class FlutterSoLoudFfi {
     return _isInited() == 1;
   }
 
-  late final _isInitedPtr =
-      _lookup<ffi.NativeFunction<ffi.Int Function()>>(
+  late final _isInitedPtr = _lookup<ffi.NativeFunction<ffi.Int Function()>>(
     'isInited',
   );
   late final _isInited = _isInitedPtr.asFunction<int Function()>();
@@ -466,8 +465,8 @@ class FlutterSoLoudFfi {
   ///
   /// [handle]
   /// Returns true if flagged for looping.
-  bool getLooping(int handle) {
-    return _getLooping(handle) == 1;
+  bool getLooping(SoundHandle handle) {
+    return _getLooping(handle.id) == 1;
   }
 
   late final _getLoopingPtr =
@@ -494,8 +493,8 @@ class FlutterSoLoudFfi {
   ///
   /// [handle]
   /// Returns the time in seconds.
-  double getLoopPoint(int handle) {
-    return _getLoopPoint(handle);
+  double getLoopPoint(SoundHandle handle) {
+    return _getLoopPoint(handle.id);
   }
 
   late final _getLoopPointPtr =
@@ -768,8 +767,8 @@ class FlutterSoLoudFfi {
 
   /// Returns the number of concurrent sounds that are playing a
   /// specific audio source.
-  int countAudioSource(int soundHash) {
-    return _countAudioSource(soundHash);
+  int countAudioSource(SoundHash soundHash) {
+    return _countAudioSource(soundHash.hash);
   }
 
   late final _countAudioSourcePtr =
@@ -788,8 +787,8 @@ class FlutterSoLoudFfi {
   late final _getVoiceCount = _getVoiceCountPtr.asFunction<int Function()>();
 
   /// Get a sound's protection state.
-  bool getProtectVoice(int handle) {
-    return _getProtectVoice(handle) == 1;
+  bool getProtectVoice(SoundHandle handle) {
+    return _getProtectVoice(handle.id) == 1;
   }
 
   late final _getProtectVoicePtr =
@@ -808,8 +807,8 @@ class FlutterSoLoudFfi {
   ///
   /// [handle]  handle to check.
   /// [protect] whether to protect or not.
-  void setProtectVoice(int handle, bool protect) {
-    return _setProtectVoice(handle, protect ? 1 : 0);
+  void setProtectVoice(SoundHandle handle, bool protect) {
+    return _setProtectVoice(handle.id, protect ? 1 : 0);
   }
 
   late final _setProtectVoicePtr =
@@ -837,9 +836,9 @@ class FlutterSoLoudFfi {
   /// NOTE: The number of concurrent voices is limited, as having unlimited
   /// voices would cause performance issues, as well as lead to unnecessary
   /// clipping. The default number of concurrent voices is 16, but this can be
-  /// adjusted at runtime. The hard maximum number is 4095, but if more are 
+  /// adjusted at runtime. The hard maximum number is 4095, but if more are
   /// required, SoLoud can be modified to support more. But seriously, if you
-  /// need more than 4095 sounds at once, you're probably going to make 
+  /// need more than 4095 sounds at once, you're probably going to make
   /// some serious changes in any case.
   void setMaxActiveVoiceCount(int maxVoiceCount) {
     return _setMaxActiveVoiceCount(maxVoiceCount);
@@ -850,7 +849,6 @@ class FlutterSoLoudFfi {
           'setMaxActiveVoiceCount');
   late final _setMaxActiveVoiceCount =
       _setMaxActiveVoiceCountPtr.asFunction<void Function(int)>();
-
 
   /////////////////////////////////////////
   /// faders
@@ -1062,9 +1060,9 @@ class FlutterSoLoudFfi {
   /// Returns:
   /// [PlayerErrors.noError] if no errors
   /// [PlayerErrors.filterNotFound] if the [filterType] does not exits
-  /// [PlayerErrors.filterAlreadyAdded] when trying to add an already 
+  /// [PlayerErrors.filterAlreadyAdded] when trying to add an already
   ///     added filter
-  /// [PlayerErrors.maxNumberOfFiltersReached] when the maximum number of 
+  /// [PlayerErrors.maxNumberOfFiltersReached] when the maximum number of
   ///     filters has been reached (default is 8)
   ///
   PlayerErrors addGlobalFilter(int filterType) {

--- a/lib/src/exceptions/exceptions_from_cpp.dart
+++ b/lib/src/exceptions/exceptions_from_cpp.dart
@@ -141,13 +141,13 @@ class SoLoudMaxFilterNumberReachedException extends SoLoudCppException {
       'is allowed (on the C++ side).';
 }
 
-/// An exception that is thrown when SoLoud (C++) cannot add a filter 
+/// An exception that is thrown when SoLoud (C++) cannot add a filter
 /// that has already been added.
 class SoLoudFilterAlreadyAddedException extends SoLoudCppException {
   /// Creates a new [SoLoudFilterAlreadyAddedException].
   const SoLoudFilterAlreadyAddedException([super.message]);
 
   @override
-  String get description => 'Askind to add a filter that is already been added. '
-      'Only one of each type is allowed (on the C++ side).';
+  String get description => 'Asking to add a filter that has '
+      'already been added. Only one of each type is allowed (on the C++ side).';
 }

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -1133,7 +1133,7 @@ interface class SoLoud {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
-    return SoLoudController().soLoudFFI.getLooping(handle.id);
+    return SoLoudController().soLoudFFI.getLooping(handle);
   }
 
   /// This function can be used to set a sample to play on repeat,
@@ -1160,7 +1160,7 @@ interface class SoLoud {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
-    return SoLoudController().soLoudFFI.getLoopPoint(handle.id);
+    return SoLoudController().soLoudFFI.getLoopPoint(handle);
   }
 
   /// Set sound loop point value.
@@ -1337,7 +1337,7 @@ interface class SoLoud {
 
   /// Returns the number of concurrent sounds that are playing a
   /// specific audio source.
-  int countAudioSource(int soundHash) {
+  int countAudioSource(SoundHash soundHash) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -1353,7 +1353,7 @@ interface class SoLoud {
   }
 
   /// Get a sound's protection state.
-  bool getProtectVoice(int handle) {
+  bool getProtectVoice(SoundHandle handle) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -1375,7 +1375,7 @@ interface class SoLoud {
   ///
   /// [handle]  handle to check.
   /// [protect] whether to protect or not.
-  void setProtectVoice(int handle, bool protect) {
+  void setProtectVoice(SoundHandle handle, bool protect) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
@@ -1794,9 +1794,9 @@ interface class SoLoud {
   /// Add a filter to all sounds.
   /// [filterType] filter to add.
   ///
-  /// Throws [SoLoudMaxFilterNumberReachedException] when the max number of 
+  /// Throws [SoLoudMaxFilterNumberReachedException] when the max number of
   ///     concurrent filter is reached (default max filter is 8).
-  /// Throws [SoLoudFilterAlreadyAddedException] when trying to add a filter 
+  /// Throws [SoLoudFilterAlreadyAddedException] when trying to add a filter
   ///     that has already been added.
   void addGlobalFilter(FilterType filterType) {
     final e = SoLoudController().soLoudFFI.addGlobalFilter(filterType.index);


### PR DESCRIPTION
## Description

The `SoLoud` API still had some methods that took `int` instead of `SoundHandle` or `SoundHash`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
