### PR TITLE
suppress cpp warnings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,7 +42,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "args": [],
-            "program": "${workspaceFolder}/example/build/windows/runner/Debug/flutter_soloud_example.exe",
+            "program": "${workspaceFolder}/example/build/windows/x64/runner/Debug/flutter_soloud_example.exe",
             "cwd": "${workspaceFolder}"
         },
         {
@@ -51,7 +51,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "args": [],
-            "program": "${workspaceFolder}/example/build/windows/runner/Debug/flutter_soloud_example.exe",
+            "program": "${workspaceFolder}/example/build/windows/x64/runner/Debug/flutter_soloud_example.exe",
             "cwd": "${workspaceFolder}"
         },
         {

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -33,6 +33,7 @@ include_directories(${SRC_DIR}/soloud/src)
 include (src.cmake)
 message("**************** SOLOUD SRC.CMAKE 2  ${TARGET_NAME}")
 
+# Suppress warnings for SoLoud lib sources
 set_source_files_properties(
   ${TARGET_SOURCES}
   PROPERTIES

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -33,6 +33,12 @@ include_directories(${SRC_DIR}/soloud/src)
 include (src.cmake)
 message("**************** SOLOUD SRC.CMAKE 2  ${TARGET_NAME}")
 
+set_source_files_properties(
+  ${TARGET_SOURCES}
+  PROPERTIES
+  COMPILE_FLAGS "-w"
+)
+
 
 
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,6 +12,8 @@ import 'package:flutter_soloud_example/page_waveform.dart';
 import 'package:logging/logging.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
   // The `flutter_soloud` package logs everything
   // (from severe warnings to fine debug messages)
   // using the standard `package:logging`.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-pre.3"
+    version: "2.0.0-pre.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/tests/tests.dart
+++ b/example/tests/tests.dart
@@ -12,6 +12,8 @@ import 'package:logging/logging.dart';
 ///
 /// Run this with `flutter run tests/tests.dart`.
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
   // Make sure we can see logs from the engine, even in release mode.
   // ignore: avoid_print
   final errorsBuffer = StringBuffer();

--- a/example/windows/flutter/CMakeLists.txt
+++ b/example/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/ios/flutter_soloud.podspec
+++ b/ios/flutter_soloud.podspec
@@ -38,7 +38,8 @@ Flutter audio plugin using SoLoud library and FFI
     ],
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited)',
     'DEFINES_MODULE' => 'YES', 
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' 
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'GCC_WARN_INHIBIT_ALL_WARNINGS' => 'YES'
   }
   s.swift_version = '5.0'
   # spec.framework      = 'SystemConfiguration'

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -33,7 +33,11 @@ include_directories(${SRC_DIR}/soloud/src)
 include (src.cmake)
 message("**************** SOLOUD SRC.CMAKE 2  ${TARGET_NAME}")
 
-
+set_source_files_properties(
+  ${TARGET_SOURCES}
+  PROPERTIES
+  COMPILE_FLAGS "-w"
+)
 
 
 list(APPEND PLUGIN_SOURCES

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -33,6 +33,7 @@ include_directories(${SRC_DIR}/soloud/src)
 include (src.cmake)
 message("**************** SOLOUD SRC.CMAKE 2  ${TARGET_NAME}")
 
+# Suppress warnings for SoLoud lib sources
 set_source_files_properties(
   ${TARGET_SOURCES}
   PROPERTIES

--- a/macos/flutter_soloud.podspec
+++ b/macos/flutter_soloud.podspec
@@ -30,7 +30,8 @@ Flutter audio plugin using SoLoud library and FFI
     ],
     'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited)',
     'DEFINES_MODULE' => 'YES', 
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' 
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'GCC_WARN_INHIBIT_ALL_WARNINGS' => 'YES'
    }
   s.swift_version = '5.0'
   s.ios.framework  = ['AudioToolbox', 'AVFAudio']

--- a/src/filters/filters.cpp
+++ b/src/filters/filters.cpp
@@ -18,7 +18,7 @@ int Filters::isFilterActive(FilterType filter)
 
     if (it != filters.end())
     {
-        int index = it - filters.begin();
+        int index = static_cast<int>(it - filters.begin());
         return index;
     }
     else

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -13,7 +13,8 @@ if (EMSCRIPTEN)
     set(CMAKE_CXX_CREATE_STATIC_LIBRARY "<CMAKE_AR> -o <TARGET> <LINK_FLAGS> <OBJECTS>")
 endif()
 
-set(CMAKE_C_FLAGS "-s STANDALONE_WASM" )
+#set(CMAKE_C_FLAGS "-s STANDALONE_WASM" )
+set(CMAKE_C_FLAGS "-s LINKABLE=1 -s EXPORT_ALL=1 -s STANDALONE_WASM" )
 
 
 ## Add SoLoud custom cmake files
@@ -24,6 +25,13 @@ include_directories(../src/soloud/include )
 include_directories(../src/soloud/src)
 include (src.cmake)
 message("**************** SOLOUD SRC.CMAKE 2  ${TARGET_NAME}")
+
+# Suppress warnings for SoLoud lib sources
+set_source_files_properties(
+  ${TARGET_SOURCES}
+  PROPERTIES
+  COMPILE_FLAGS "-w"
+)
 
 
 list(APPEND PLUGIN_SOURCES

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -33,6 +33,7 @@ include_directories(${SRC_DIR}/soloud/src)
 include (src.cmake)
 message("**************** SOLOUD SRC.CMAKE 2  ${TARGET_NAME}")
 
+# Suppress warnings for SoLoud lib sources
 set_source_files_properties(
   ${TARGET_SOURCES}
   PROPERTIES

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -33,6 +33,12 @@ include_directories(${SRC_DIR}/soloud/src)
 include (src.cmake)
 message("**************** SOLOUD SRC.CMAKE 2  ${TARGET_NAME}")
 
+set_source_files_properties(
+  ${TARGET_SOURCES}
+  PROPERTIES
+  COMPILE_FLAGS "-w"
+)
+
 
 
 


### PR DESCRIPTION
## Description

Suppress all warnings coming from the SoLoud lib.
On macOS and iOS all warnings are suppressed.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
