### PR TITLE
fix: crash on deinit() #68 and parameters retention after deinit()

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-pre.3"
+    version: "2.0.0-pre.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -101,7 +101,10 @@ enum PlayerErrors {
   maxNumberOfFiltersReached(14),
 
   /// The filter has already been added.
-  filterAlreadyAdded(15);
+  filterAlreadyAdded(15),
+
+  /// Player already inited.
+  playerAlreadyInited(16);
 
   const PlayerErrors(this.value);
 
@@ -147,6 +150,8 @@ enum PlayerErrors {
         return 'The maximum number of filters has been reached (default is 8)!';
       case PlayerErrors.filterAlreadyAdded:
         return 'Filter not found!';
+      case PlayerErrors.playerAlreadyInited:
+        return 'The player has already been inited!';
     }
   }
 

--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -97,6 +97,8 @@ abstract class SoLoudCppException extends SoLoudException {
         return const SoLoudMaxFilterNumberReachedException();
       case PlayerErrors.filterAlreadyAdded:
         return const SoLoudFilterAlreadyAddedException();
+      case PlayerErrors.playerAlreadyInited:
+        return const SoLoudPlayerAlreadyInitializedException();
     }
   }
 }

--- a/lib/src/exceptions/exceptions_from_cpp.dart
+++ b/lib/src/exceptions/exceptions_from_cpp.dart
@@ -151,3 +151,14 @@ class SoLoudFilterAlreadyAddedException extends SoLoudCppException {
   String get description => 'Asking to add a filter that has '
       'already been added. Only one of each type is allowed (on the C++ side).';
 }
+
+/// An exception that is thrown when SoLoud (C++) cannot add a filter
+/// that has already been added.
+class SoLoudPlayerAlreadyInitializedException extends SoLoudCppException {
+  /// Creates a new [SoLoudPlayerAlreadyInitializedException].
+  const SoLoudPlayerAlreadyInitializedException([super.message]);
+
+  @override
+  String get description => 'The player has already been initialized '
+      '(on the C++ side).';
+}

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -1402,7 +1402,6 @@ interface class SoLoud {
   /// required, SoLoud can be modified to support more. But seriously, if you
   /// need more than 4095 sounds at once, you're probably going to make
   /// some serious changes in any case.
-  // TODO(filiph): Make sure the set maxVoiceCount _doesn't_ survive deinit
   void setMaxActiveVoiceCount(int maxVoiceCount) {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();

--- a/src/enums.h
+++ b/src/enums.h
@@ -40,6 +40,8 @@ typedef enum PlayerErrors
     maxNumberOfFiltersReached = 14,
     /// The filter has already been added.
     filterAlreadyAdded = 15,
+    /// Player already inited.
+    playerAlreadyInited = 16,
 } PlayerErrors_t;
 
 /// Possible capture errors

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2,6 +2,7 @@
 #include "player.h"
 #include "soloud.h"
 #include "soloud_wav.h"
+// #include "soloud_thread.h"
 #include "soloud_wavstream.h"
 #include "synth/basic_wave.h"
 
@@ -23,7 +24,7 @@ Player::~Player()
 
 PlayerErrors Player::init()
 {
-    if (mInited) dispose();
+    if (mInited) return playerAlreadyInited;
     
     std::lock_guard<std::mutex> guard(init_deinit_mutex);
 
@@ -32,7 +33,7 @@ PlayerErrors Player::init()
         SoLoud::Soloud::CLIP_ROUNDOFF,
         SoLoud::Soloud::MINIAUDIO, 44100, 2048, 2U);
     // soloud.init(1U, 0U, 44100, 2048, 2U);
-    // SoLoud::Thread::sleep(100);
+    // SoLoud::Thread::sleep(1000);
     if (result == SoLoud::SO_NO_ERROR)
         mInited = true;
     else
@@ -95,6 +96,8 @@ const std::string Player::getErrorString(PlayerErrors errorCode) const
         return "error: max number of filter reached!";
     case filterAlreadyAdded:
         return "error: filter already added!";
+    case playerAlreadyInited:
+        return "error: the player is already initialized!";
     }
     return "Other error";
 }

--- a/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
+++ b/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
@@ -43,6 +43,20 @@ namespace SoLoud
 #define MA_NO_WAV
 #define MA_NO_FLAC
 #define MA_NO_MP3
+#define MA_NO_AUTOINITIALIZATION
+#define MA_NO_VORBIS
+#define MA_NO_OPUS
+#define MA_NO_MIDI
+
+// Seems that on miniaudio there is still an issue when uninitializing the device
+// addressed by this issue: https://github.com/mackron/miniaudio/issues/466
+// For me this happens using AAudio on android <= 10 (but not on Samsung Galaxy S9+).
+// Disablig AAudio in favor of OpenSL is a workaround to prevent the crash.
+#if defined(__ANDROID__) && (__ANDROID_API__ <= 29)
+#define MA_NO_AAUDIO
+#endif
+// #define MA_DEBUG_OUTPUT
+// #define MINIAUDIO_IMPLEMENTATION
 #include "miniaudio.h"
 #include <math.h>
 


### PR DESCRIPTION
## Description

Fixes for #68:
- AAudio disabled in favor of OpenSL for Android <= 29
- added `PlayerErrors.playerAlreadyInited` exception from cpp
- `tests.dart` updated to check sync/async `init()`-`deinit()`

Fix for parameters retention after `deinit()`
- after calling `deinit()` and then `init()` again, some player parameters like the max active voice count, was persisting. `player.cpp` has been updated to prevent this.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
