### PR TITLE
fix: Init error on hot restart #81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.0.1 (6 May 2024)
+- Fix init error on hot restart.
+
 ### 2.0.0 (5 Apr 2024)
 - A giant leap forward from the previous version (many thanks to Filip Hráček).
 - Major changes to API. There are quick fixes (`dart fix`) to automatically rename many changed APIs.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-pre.4"
+    version: "2.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -292,7 +292,11 @@ interface class SoLoud {
     // the release of the native player.
     // Just deinit the engine to be re-inited later.
     if (SoLoudController().soLoudFFI.isInited()) {
-      _log.warning("init() called when the native player is already initialized. This is expected after a hot restart but not otherwise. If you see this in production logs, there's probably a bug in your code. You may have neglected to deinit() SoLoud during the current lifetime of the app.");
+      _log.warning('init() called when the native player is already '
+        'initialized. This is expected after a hot restart but not otherwise. '
+        "If you see this in production logs, there's probably a bug in "
+        'your code. You may have neglected to deinit() SoLoud during the '
+        'current lifetime of the app.');
       deinit();
     }
 

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -293,10 +293,10 @@ interface class SoLoud {
     // Just deinit the engine to be re-inited later.
     if (SoLoudController().soLoudFFI.isInited()) {
       _log.warning('init() called when the native player is already '
-          'initialized. This is expected after a hot restart but not otherwise. '
-          "If you see this in production logs, there's probably a bug in "
-          'your code. You may have neglected to deinit() SoLoud during the '
-          'current lifetime of the app.');
+          'initialized. This is expected after a hot restart but not '
+          "otherwise. If you see this in production logs, there's probably "
+          'a bug in your code. You may have neglected to deinit() SoLoud '
+          'during the current lifetime of the app.');
       deinit();
     }
 

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -287,6 +287,14 @@ interface class SoLoud {
       return;
     }
 
+    // if `!_isInitialized` but the engine is initialized in native, therefore
+    // the developer may have carried out a hot reload which does not imply 
+    // the release of the native player. 
+    // Just deinit the engine to be re-inited later.
+    if (SoLoudController().soLoudFFI.isInited()) {
+      deinit();
+    }
+
     if (_initializeCompleter != null) {
       _log.severe('initialize() called while already initializing. '
           'Avoid this by checking the `initialized` Future before '

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -288,8 +288,8 @@ interface class SoLoud {
     }
 
     // if `!_isInitialized` but the engine is initialized in native, therefore
-    // the developer may have carried out a hot reload which does not imply 
-    // the release of the native player. 
+    // the developer may have carried out a hot reload which does not imply
+    // the release of the native player.
     // Just deinit the engine to be re-inited later.
     if (SoLoudController().soLoudFFI.isInited()) {
       deinit();

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -292,6 +292,7 @@ interface class SoLoud {
     // the release of the native player.
     // Just deinit the engine to be re-inited later.
     if (SoLoudController().soLoudFFI.isInited()) {
+      _log.warning("init() called when the native player is already initialized. This is expected after a hot restart but not otherwise. If you see this in production logs, there's probably a bug in your code. You may have neglected to deinit() SoLoud during the current lifetime of the app.");
       deinit();
     }
 

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -293,10 +293,10 @@ interface class SoLoud {
     // Just deinit the engine to be re-inited later.
     if (SoLoudController().soLoudFFI.isInited()) {
       _log.warning('init() called when the native player is already '
-        'initialized. This is expected after a hot restart but not otherwise. '
-        "If you see this in production logs, there's probably a bug in "
-        'your code. You may have neglected to deinit() SoLoud during the '
-        'current lifetime of the app.');
+          'initialized. This is expected after a hot restart but not otherwise. '
+          "If you see this in production logs, there's probably a bug in "
+          'your code. You may have neglected to deinit() SoLoud during the '
+          'current lifetime of the app.');
       deinit();
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A low-level audio plugin for Flutter,
   mainly meant for games and immersive apps.
   Based on the SoLoud (C++) audio engine.
-version: 2.0.0
+version: 2.0.1
 issue_tracker: https://github.com/alnitak/flutter_soloud/issues
 homepage: https://github.com/alnitak/flutter_soloud
 maintainer: Marco Bavagnoli (@lildeimos)


### PR DESCRIPTION
## Description

Fix hot reload `SoLoudPlayerAlreadyInitializedException` issue #81.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
