### PR TITLE
removed cpp exception check from setVolume

### DIFF
--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -104,7 +104,10 @@ enum PlayerErrors {
   filterAlreadyAdded(15),
 
   /// Player already inited.
-  playerAlreadyInited(16);
+  playerAlreadyInited(16),
+
+  /// Audio handle is not found
+  soundHandleNotFound(17);
 
   const PlayerErrors(this.value);
 
@@ -152,6 +155,9 @@ enum PlayerErrors {
         return 'Filter not found!';
       case PlayerErrors.playerAlreadyInited:
         return 'The player has already been inited!';
+      case PlayerErrors.soundHandleNotFound:
+        return 'The handle is not found! The playing handle could have been '
+            'stopped or ended and it is no more valid!';
     }
   }
 

--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -100,7 +100,7 @@ abstract class SoLoudCppException extends SoLoudException {
       case PlayerErrors.playerAlreadyInited:
         return const SoLoudPlayerAlreadyInitializedException();
       case PlayerErrors.soundHandleNotFound:
-        return const SoLoudSoundHashNotFoundCppException();
+        return const SoLoudSoundHandleNotFoundCppException();
     }
   }
 }

--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -99,6 +99,8 @@ abstract class SoLoudCppException extends SoLoudException {
         return const SoLoudFilterAlreadyAddedException();
       case PlayerErrors.playerAlreadyInited:
         return const SoLoudPlayerAlreadyInitializedException();
+      case PlayerErrors.soundHandleNotFound:
+        return const SoLoudSoundHashNotFoundCppException();
     }
   }
 }

--- a/lib/src/exceptions/exceptions_from_cpp.dart
+++ b/lib/src/exceptions/exceptions_from_cpp.dart
@@ -91,7 +91,7 @@ class SoLoudNullPointerException extends SoLoudCppException {
 /// An exception that is thrown when SoLoud (C++) receives a sound hash
 /// that is not found.
 class SoLoudSoundHashNotFoundCppException extends SoLoudCppException {
-  /// Creates a new [SoLoudSoundHashNotFoundDartException].
+  /// Creates a new [SoLoudSoundHashNotFoundCppException].
   const SoLoudSoundHashNotFoundCppException([super.message]);
 
   @override
@@ -160,5 +160,18 @@ class SoLoudPlayerAlreadyInitializedException extends SoLoudCppException {
 
   @override
   String get description => 'The player has already been initialized '
+      '(on the C++ side).';
+}
+
+/// An exception that is thrown when SoLoud (C++) receives a handle
+/// that is not found. This could happen when trying to use the given handle
+/// to get/set some of its attributes (like setting handle volume) after the
+/// handle has been stopped/ended and hence it becomes invalid.
+class SoLoudSoundHandleNotFoundCppException extends SoLoudCppException {
+  /// Creates a new [SoLoudSoundHandleNotFoundCppException].
+  const SoLoudSoundHandleNotFoundCppException([super.message]);
+
+  @override
+  String get description => 'The sound handle is not found '
       '(on the C++ side).';
 }

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -1229,12 +1229,7 @@ interface class SoLoud {
     if (!isInitialized) {
       throw const SoLoudNotInitializedException();
     }
-    final ret = SoLoudController().soLoudFFI.setVolume(handle, volume);
-    final error = PlayerErrors.values[ret];
-    if (error != PlayerErrors.noError) {
-      _log.severe(() => 'setVolume(): $error');
-      throw SoLoudCppException.fromPlayerError(error);
-    }
+    SoLoudController().soLoudFFI.setVolume(handle, volume);
   }
 
   /// Check if the [handle] is still valid.

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -93,14 +93,14 @@ extern "C"
     /// all audio data into memory. This will be useful when
     /// the audio is short, ie for game sounds, mainly used to prevent
     /// gaps or lags when starting a sound (less CPU, more memory allocated).
-    /// If false, Soloud::wavStream will be used and the audio data is loaded 
+    /// If false, Soloud::wavStream will be used and the audio data is loaded
     /// from the given file when needed (more CPU, less memory allocated).
     /// See the [seek] note problem when using [loadIntoMem] = false
     /// [hash] return hash of the sound
     /// Returns [PlayerErrors.noError] if success
     FFI_PLUGIN_EXPORT enum PlayerErrors loadFile(
-        char *completeFileName, 
-        bool loadIntoMem, 
+        char *completeFileName,
+        bool loadIntoMem,
         unsigned int *hash)
     {
         if (!player.get()->isInited())
@@ -221,7 +221,7 @@ extern "C"
     /// [handle] the sound handle
     FFI_PLUGIN_EXPORT void pauseSwitch(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return;
         player.get()->pauseSwitch(handle);
@@ -233,7 +233,7 @@ extern "C"
     /// [pause] the sound handle
     FFI_PLUGIN_EXPORT void setPause(unsigned int handle, bool pause)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return;
         player.get()->setPause(handle, pause);
@@ -265,7 +265,7 @@ extern "C"
     /// [speed] the new speed
     FFI_PLUGIN_EXPORT void setRelativePlaySpeed(unsigned int handle, float speed)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return;
         player.get()->setRelativePlaySpeed(handle, speed);
@@ -278,7 +278,7 @@ extern "C"
     /// [handle] the sound handle
     FFI_PLUGIN_EXPORT float getRelativePlaySpeed(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return 1;
         return player.get()->getRelativePlaySpeed(handle);
@@ -292,9 +292,9 @@ extern "C"
     /// [paused] 0 not paused
     /// [newHandle] pointer to the handle for this new sound
     /// [looping] whether to start the sound in looping state.
-    /// [loopingStartAt] If looping is enabled, the loop point is, by default, 
-    /// the start of the stream. The loop start point can be set with this parameter, and 
-    /// current loop point can be queried with [getLoopingPoint] and 
+    /// [loopingStartAt] If looping is enabled, the loop point is, by default,
+    /// the start of the stream. The loop start point can be set with this parameter, and
+    /// current loop point can be queried with [getLoopingPoint] and
     /// changed by [setLoopingPoint].
     /// Return the error if any and a new [handle] of this sound
     FFI_PLUGIN_EXPORT enum PlayerErrors play(
@@ -317,7 +317,7 @@ extern "C"
     /// [handle]
     FFI_PLUGIN_EXPORT void stop(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return;
         player.get()->stop(handle);
@@ -348,7 +348,7 @@ extern "C"
     /// Returns true if flagged for looping.
     FFI_PLUGIN_EXPORT int getLooping(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return 0;
         return player.get()->getLooping(handle) == 1;
@@ -361,7 +361,7 @@ extern "C"
     /// [enable]
     FFI_PLUGIN_EXPORT void setLooping(unsigned int handle, bool enable)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return;
         player.get()->setLooping(handle, enable);
@@ -373,7 +373,7 @@ extern "C"
     /// Returns the time in seconds.
     FFI_PLUGIN_EXPORT double getLoopPoint(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return 0;
         return player.get()->getLoopPoint(handle);
@@ -385,7 +385,7 @@ extern "C"
     /// [time] in seconds.
     FFI_PLUGIN_EXPORT void setLoopPoint(unsigned int handle, double time)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return;
         player.get()->setLoopPoint(handle, time);
@@ -457,7 +457,7 @@ extern "C"
     /// [samples] should be allocated and freed in dart side
     FFI_PLUGIN_EXPORT void getAudioTexture(float *samples)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             analyzer.get() == nullptr)
         {
             memset(samples, 0, sizeof(float) * 512);
@@ -480,7 +480,7 @@ extern "C"
     float texture2D[512][256];
     FFI_PLUGIN_EXPORT enum PlayerErrors getAudioTexture2D(float **samples)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             analyzer.get() == nullptr || !player.get()->isVisualizationEnabled())
         {
             if (*samples == nullptr)
@@ -512,16 +512,16 @@ extern "C"
     /// [time]
     /// [handle] the sound handle
     /// Returns [PlayerErrors.noError] if success
-    /// 
+    ///
     /// NOTE: when seeking an mp3 file loaded using `loadIntoMem`=false
-    /// the seek operation is not performed due to lags. This occurs because the 
+    /// the seek operation is not performed due to lags. This occurs because the
     /// mp3 codec must compute each frame length to gain a new position.
     /// The problem is explained in souloud_wavstream.cpp
     /// in `WavStreamInstance::seek` function.
     ///
     /// This mode is useful ie for background music, not for a music player
     /// where a seek slider for mp3s is a must.
-    /// If you need seeking mp3, please, use `loadIntoMem`=true instead 
+    /// If you need seeking mp3, please, use `loadIntoMem`=true instead
     /// or other audio formats!
     ///
     FFI_PLUGIN_EXPORT enum PlayerErrors seek(unsigned int handle, float time)
@@ -537,7 +537,7 @@ extern "C"
     /// Returns time in seconds
     FFI_PLUGIN_EXPORT double getPosition(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return 0.0;
         return player.get()->getPosition(handle);
@@ -569,7 +569,7 @@ extern "C"
     /// Returns the volume
     FFI_PLUGIN_EXPORT double getVolume(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return 0.0;
         return player.get()->getVolume(handle);
@@ -577,12 +577,12 @@ extern "C"
 
     /// Set current [handle] volume
     ///
-    /// Returns the volume
     FFI_PLUGIN_EXPORT enum PlayerErrors setVolume(unsigned int handle, float volume)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
-            !player.get()->isValidVoiceHandle(handle))
+        if (player.get() == nullptr || !player.get()->isInited())
             return backendNotInited;
+        if (!player.get()->isValidVoiceHandle(handle))
+            return soundHandleNotFound;
         player.get()->setVolume(handle, volume);
         return noError;
     }
@@ -593,7 +593,7 @@ extern "C"
     /// Return true if it still exists
     FFI_PLUGIN_EXPORT int getIsValidVoiceHandle(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return false;
         return player.get()->isValidVoiceHandle(handle) ? 1 : 0;
@@ -626,7 +626,7 @@ extern "C"
     /// Get a sound's protection state.
     FFI_PLUGIN_EXPORT bool getProtectVoice(unsigned int handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return false;
         return player.get()->getProtectVoice(handle);
@@ -644,7 +644,7 @@ extern "C"
     /// [protect] whether to protect or not.
     FFI_PLUGIN_EXPORT void setProtectVoice(unsigned int handle, bool protect)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             !player.get()->isValidVoiceHandle(handle))
             return;
         player.get()->setProtectVoice(handle, protect);
@@ -785,11 +785,11 @@ extern "C"
     /////////////////////////////////////////
 
     /// Check if the given filter is active or not.
-    /// 
+    ///
     /// [filterType] filter to check
     /// Returns [PlayerErrors.noError] if no errors and the index of
     /// the given filter (-1 if the filter is not active)
-    /// 
+    ///
     FFI_PLUGIN_EXPORT enum PlayerErrors isFilterActive(enum FilterType filterType, int *index)
     {
         *index = -1;
@@ -800,7 +800,7 @@ extern "C"
     }
 
     /// Get parameters names of the given filter.
-    /// 
+    ///
     /// [filterType] filter to get param names
     /// Returns [PlayerErrors.noError] if no errors and the list of param names
     ///
@@ -814,7 +814,8 @@ extern "C"
         *paramsCount = static_cast<int>(pNames.size());
         *names = (char *)malloc(sizeof(char *) * *paramsCount);
         printf("C  paramsCount: %p  **names: %p\n", paramsCount, names);
-        for (int i = 0; i < *paramsCount; i++) {
+        for (int i = 0; i < *paramsCount; i++)
+        {
             names[i] = strdup(pNames[i].c_str());
             printf("C  i: %d  names[i]: %s  names[i]: %p\n", i, names[i], names[i]);
         }
@@ -822,10 +823,10 @@ extern "C"
     }
 
     /// Add the filter [filterType] to all sounds.
-    /// 
+    ///
     /// [filterType] filter to add
     /// Returns [PlayerErrors.noError] if no errors
-    /// 
+    ///
     FFI_PLUGIN_EXPORT enum PlayerErrors addGlobalFilter(enum FilterType filterType)
     {
         if (player.get() == nullptr || !player.get()->isInited())
@@ -834,10 +835,10 @@ extern "C"
     }
 
     /// Remove the filter [filterType].
-    /// 
+    ///
     /// [filterType] filter to remove
     /// Returns [PlayerErrors.noError] if no errors
-    /// 
+    ///
     FFI_PLUGIN_EXPORT enum PlayerErrors removeGlobalFilter(enum FilterType filterType)
     {
         if (player.get() == nullptr || !player.get()->isInited())
@@ -847,12 +848,12 @@ extern "C"
         return noError;
     }
 
-    /// Set the effect parameter with id [attributeId] 
+    /// Set the effect parameter with id [attributeId]
     /// of [filterType] with [value] value.
-    /// 
+    ///
     /// [filterType] filter to modify a param
     /// Returns [PlayerErrors.noError] if no errors
-    /// 
+    ///
     FFI_PLUGIN_EXPORT enum PlayerErrors setFxParams(enum FilterType filterType, int attributeId, float value)
     {
         if (player.get() == nullptr || !player.get()->isInited())
@@ -862,10 +863,10 @@ extern "C"
     }
 
     /// Get the effect parameter with id [attributeId] of [filterType].
-    /// 
+    ///
     /// [filterType] filter to modify a param
     /// Returns the value of param
-    /// 
+    ///
     FFI_PLUGIN_EXPORT float getFxParams(enum FilterType filterType, int attributeId)
     {
         if (player.get() == nullptr || !player.get()->isInited())
@@ -882,9 +883,9 @@ extern "C"
     /// [posX], [posY], [posZ] are the audio source position coordinates.
     /// [velX], [velY], [velZ] are the audio source velocity.
     /// [looping] whether to start the sound in looping state.
-    /// [loopingStartAt] If looping is enabled, the loop point is, by default, 
-    /// the start of the stream. The loop start point can be set with this parameter, and 
-    /// current loop point can be queried with [getLoopingPoint] and 
+    /// [loopingStartAt] If looping is enabled, the loop point is, by default,
+    /// the start of the stream. The loop start point can be set with this parameter, and
+    /// current loop point can be queried with [getLoopingPoint] and
     /// changed by [setLoopingPoint].
     /// Returns the handle of the sound, 0 if error
     FFI_PLUGIN_EXPORT unsigned int play3d(
@@ -901,7 +902,7 @@ extern "C"
         double loopingStartAt,
         unsigned int *handle)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return backendNotInited;
 
@@ -929,7 +930,7 @@ extern "C"
     /// and that the environment is dry air at around 20 degrees Celsius.
     FFI_PLUGIN_EXPORT void set3dSoundSpeed(float speed)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dSoundSpeed(speed);
@@ -939,7 +940,7 @@ extern "C"
     /// Get the sound speed
     FFI_PLUGIN_EXPORT float get3dSoundSpeed()
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return 0.0f;
         return player.get()->get3dSoundSpeed();
@@ -953,7 +954,7 @@ extern "C"
         float upX, float upY, float upZ,
         float velocityX, float velocityY, float velocityZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dListenerParameters(
@@ -970,7 +971,7 @@ extern "C"
         float posY,
         float posZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dListenerPosition(posX, posY, posZ);
@@ -983,7 +984,7 @@ extern "C"
         float atY,
         float atZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dListenerAt(atX, atY, atZ);
@@ -996,7 +997,7 @@ extern "C"
         float upY,
         float upZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dListenerAt(upX, upY, upZ);
@@ -1009,7 +1010,7 @@ extern "C"
         float velocityY,
         float velocityZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dListenerVelocity(velocityX, velocityY, velocityZ);
@@ -1023,12 +1024,12 @@ extern "C"
         float posX, float posY, float posZ,
         float velocityX, float velocityY, float velocityZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dSourceParameters(handle,
-                                     posX, posY, posZ,
-                                     velocityX, velocityY, velocityZ);
+                                            posX, posY, posZ,
+                                            velocityX, velocityY, velocityZ);
         player.get()->update3dAudio();
     }
 
@@ -1039,7 +1040,7 @@ extern "C"
         float posY,
         float posZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dSourcePosition(handle, posX, posY, posZ);
@@ -1053,7 +1054,7 @@ extern "C"
         float velocityY,
         float velocityZ)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dSourceVelocity(handle, velocityX, velocityY, velocityZ);
@@ -1067,7 +1068,7 @@ extern "C"
         float minDistance,
         float maxDistance)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dSourceMinMaxDistance(handle, minDistance, maxDistance);
@@ -1087,7 +1088,7 @@ extern "C"
         unsigned int attenuationModel,
         float attenuationRolloffFactor)
     {
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dSourceAttenuation(handle, attenuationModel, attenuationRolloffFactor);
@@ -1099,8 +1100,7 @@ extern "C"
         unsigned int handle,
         float dopplerFactor)
     {
-
-        if (player.get() == nullptr || !player.get()->isInited() || 
+        if (player.get() == nullptr || !player.get()->isInited() ||
             player.get()->getSoundsCount() == 0)
             return;
         player.get()->set3dSourceDopplerFactor(handle, dopplerFactor);
@@ -1118,15 +1118,6 @@ extern "C"
         // SoLoud::result result = soloud.init(
         //     SoLoud::Soloud::CLIP_ROUNDOFF,
         //     SoLoud::Soloud::MINIAUDIO, 44100, 2048, 2U);
-        // result = sound1.load("/home/deimos/5/01 - Theme From Farscape.mp3");
-        // result = sound2.load("/home/deimos/5/Music/ROSS/DANCE/Alphaville - Big In Japan (Original Version).mp3");
-
-        // soloud.play(sound1, -1.0f, 0.0f, 0, 0);
-        // soloud.play(sound2, -1.0f, 0.0f, 0, 0);
-
-        // unsigned int handle;
-        // player.get()->play("/home/deimos/5/01 - Theme From Farscape.mp3", handle);
-        // player.get()->play("/home/deimos/5/Music/ROSS/DANCE/Alphaville - Big In Japan (Original Version).mp3", handle);
 
         // unsigned int hash;
         // player.get()->loadWaveform(SoLoud::Soloud::WAVE_SQUARE, true, 0.25f, 1.0f, hash);

--- a/src/enums.h
+++ b/src/enums.h
@@ -28,7 +28,7 @@ typedef enum PlayerErrors
     unknownError = 8,
     /// Player not initialized
     nullPointer = 9,
-    /// audio sound hash has not found
+    /// Audio sound hash is not found
     soundHashNotFound = 10,
     /// Player not initialized
     backendNotInited = 11,
@@ -42,6 +42,8 @@ typedef enum PlayerErrors
     filterAlreadyAdded = 15,
     /// Player already inited.
     playerAlreadyInited = 16,
+    /// Audio handle is not found
+    soundHandleNotFound = 17,
 } PlayerErrors_t;
 
 /// Possible capture errors

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -98,6 +98,8 @@ const std::string Player::getErrorString(PlayerErrors errorCode) const
         return "error: filter already added!";
     case playerAlreadyInited:
         return "error: the player is already initialized!";
+    case soundHandleNotFound:
+        return "error: audio handle is not found!";
     }
     return "Other error";
 }


### PR DESCRIPTION
## Description

Since only `setVolume()` was checking for a possible "handle not found" exception, I've removed that.

All the other methods that need a `SoundHandle` as a parameter don't throw a cpp exception and don't log anything. Therefore, when using a voice handle that is already ended/stopped nothing happens as discussed in issue #83.

We could think about just displaying a log for all the methods that need a `SoundHandle` without throwing.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
