### PR TITLE
Use C++ 17 to build on iOS

### DIFF
--- a/ios/flutter_soloud.podspec
+++ b/ios/flutter_soloud.podspec
@@ -27,7 +27,8 @@ Flutter audio plugin using SoLoud library and FFI
     '-w',
     '-DOS_OBJECT_USE_OBJC=0', '-Wno-format',
     '-lpthread',
-    '-lm'
+    '-lm',
+    '-std=c++17'
   ]
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Forcing the use of C++ 17 when building for iOS, as 46c6f4bd2d816eff58ca4033cb4b6c4ce9886bf1 does for Android and Windows. The XCode toolchain on MacOS seems to use C++ 11 by default for compilation and the plugin fails to be built. It was confirmed that the addition of this flag helps in building the plugin successfully.  

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
