### PR TITLE
Fix waveform and iOS compilation issue

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Flutter debug",
             "type": "dart",
             "request": "launch",
-            "program": "lib/filters/pitchshift.dart",
+            "program": "lib/main.dart",
             "flutterMode": "debug",
             "cwd": "${workspaceFolder}/example"
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
         },
         {
             "label": "compile linux debug",
-            "command": "cd ${workspaceFolder}/example; flutter build linux -t lib/filters/pitchshift.dart --debug",
+            "command": "cd ${workspaceFolder}/example; flutter build linux -t lib/main.dart --debug",
             "type": "shell"
         },
         {
@@ -29,7 +29,7 @@
         },
         {
             "label": "compile web debug",
-            "command": "cd ${workspaceFolder}/example; flutter run -d chrome --web-renderer canvaskit --web-browser-flag '--disable-web-security' -t lib/audio_data/audio_data.dart --release",
+            "command": "cd ${workspaceFolder}/example; flutter run -d chrome --web-renderer canvaskit --web-browser-flag '--disable-web-security' -t lib/main.dart --release",
             "type": "shell"
         }
     ]

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -39,8 +39,6 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - permission_handler_apple (9.1.1):
-    - Flutter
   - SDWebImage (5.16.0):
     - SDWebImage/Core (= 5.16.0)
   - SDWebImage/Core (5.16.0)
@@ -51,7 +49,6 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_soloud (from `.symlinks/plugins/flutter_soloud/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
-  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
 SPEC REPOS:
   trunk:
@@ -69,20 +66,17 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_soloud/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
-  permission_handler_apple:
-    :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
   DKPhotoGallery: fdfad5125a9fdda9cc57df834d49df790dbb4179
-  file_picker: ce3938a0df3cc1ef404671531facef740d03f920
+  file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_soloud: a49590bf8d8be2c55b50f4d4e819b764901a4946
-  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
-  permission_handler_apple: e76247795d700c14ea09e3a2d8855d41ee80a2e6
+  flutter_soloud: 8e3e36e6543681eb9b404e5f4e66dd957adc38dc
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   SDWebImage: 2aea163b50bfcb569a2726b6a754c54a4506fcf6
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 
-COCOAPODS: 1.15.0
+COCOAPODS: 1.15.2

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/waveform/waveform.dart
+++ b/example/lib/waveform/waveform.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_soloud/flutter_soloud.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({required this.title, super.key});
+
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  double frequency = 1000;
+  AudioSource? currentSound;
+  SoundHandle? soundHandle;
+  bool isPlaying = false;
+
+  @override
+  void dispose() {
+    stop();
+    SoLoud.instance.deinit();
+    super.dispose();
+  }
+
+  Future<void> play(double frequency) async {
+    try {
+      if (!SoLoud.instance.isInitialized) {
+        await SoLoud.instance.init();
+      }
+
+      if (isPlaying) {
+        await stop();
+      }
+
+      currentSound =
+          await SoLoud.instance.loadWaveform(WaveForm.sin, true, 1, 0);
+
+      soundHandle = await SoLoud.instance.play(
+        currentSound!,
+        loopingStartAt: const Duration(seconds: 5),
+        looping: true,
+      );
+
+      setState(() {
+        isPlaying = true;
+      });
+
+      SoLoud.instance.setWaveformFreq(currentSound!, frequency);
+    } catch (e) {
+      debugPrint('Error while trying to play sound: $e');
+    }
+  }
+
+  Future<void> stop() async {
+    try {
+      if (soundHandle != null && isPlaying) {
+        await SoLoud.instance.stop(soundHandle!);
+        setState(() {
+          isPlaying = false;
+        });
+      }
+    } catch (e) {
+      debugPrint('Error while trying to stop sound: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Freequncy : $frequency'),
+            Slider(
+              value: frequency,
+              min: 20,
+              max: 16000,
+              onChanged: (value) {
+                setState(() {
+                  frequency = value;
+
+                  if (currentSound != null && isPlaying) {
+                    SoLoud.instance.setWaveformFreq(currentSound!, value);
+                  }
+                });
+              },
+              label: 'Frequency: ${frequency.toStringAsFixed(0)} Hz',
+              activeColor: Colors.green,
+              inactiveColor: Colors.green[100],
+            ),
+            const SizedBox(height: 50),
+            ElevatedButton(
+              onPressed: isPlaying ? null : () => play(frequency),
+              child: const Text('Play'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: isPlaying ? stop : null,
+              child: const Text('Stop'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -100,7 +100,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.2"
+    version: "2.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/ffigen.yaml
+++ b/ffigen.yaml
@@ -1,4 +1,4 @@
-# Run with `flutter pub run ffigen --config ffigen_player.yaml`.
+# Run with `flutter pub run ffigen --config ffigen.yaml`.
 name: FlutterSoLoudFfi
 description: 'FFI bindings to SoLoud'
 output: 'lib/flutter_soloud_FFIGEN.dart'

--- a/ios/flutter_soloud.podspec
+++ b/ios/flutter_soloud.podspec
@@ -23,7 +23,8 @@ Flutter audio plugin using SoLoud library and FFI
   s.platform = :ios, '13.0'
 
   s.compiler_flags      = [
-    '-GCC_WARN_INHIBIT_ALL_WARNINGS',
+    # fix for #130. This maybe is temporary solution till a new XCode will be released.
+    # '-GCC_WARN_INHIBIT_ALL_WARNINGS',
     '-w',
     '-DOS_OBJECT_USE_OBJC=0', '-Wno-format',
     '-lpthread',

--- a/ios/flutter_soloud.podspec
+++ b/ios/flutter_soloud.podspec
@@ -20,7 +20,7 @@ Flutter audio plugin using SoLoud library and FFI
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '13.0'
 
   s.compiler_flags      = [
     '-GCC_WARN_INHIBIT_ALL_WARNINGS',

--- a/src/player.h
+++ b/src/player.h
@@ -188,7 +188,6 @@ public:
     void disposeSound(unsigned int soundHash);
 
     /// @brief Dispose all sounds already loaded.
-    /// @param soundHash hash of the sound.
     void disposeAllSound();
 
     /// @brief Ask whether a sound is set to loop or not.
@@ -340,7 +339,7 @@ public:
     ActiveSound *findByHandle(SoLoud::handle handle);
 
     /// @brief Find a sound by its handle.
-    /// @param handle the handle to search.
+    /// @param hash the hash to search.
     /// @return If not found, return nullptr.
     ActiveSound *findByHash(unsigned int hash);
 

--- a/src/synth/basic_wave.cpp
+++ b/src/synth/basic_wave.cpp
@@ -35,15 +35,15 @@ BasicwaveInstance::BasicwaveInstance(Basicwave *aParent)
 unsigned int BasicwaveInstance::getAudio(float *aBuffer, unsigned int aSamplesToRead, unsigned int aBufferSize)
 {
     unsigned int i;
-    float d = 1.0f / mSamplerate;
+    double d = 1.0 / mSamplerate;
     if (!mParent->mSuperwave)
     {
         for (i = 0; i < aSamplesToRead; i++)
         {
             aBuffer[i] = SoLoud::Misc::generateWaveform(
                              mParent->mWaveform,
-                             (float)fmod(mParent->mFreq * (float)mOffset, 1.0f)) *
-                         mParent->mADSR.val(mT, 10000000000000.0f);
+                             (double)fmod(mParent->mFreq * (double)mOffset, 1.0)) *
+                         mParent->mADSR.val(mT, 10000000000000.0);
             mOffset++;
             mT += d;
         }
@@ -53,15 +53,15 @@ unsigned int BasicwaveInstance::getAudio(float *aBuffer, unsigned int aSamplesTo
         for (i = 0; i < aSamplesToRead; i++)
         {
             aBuffer[i] = SoLoud::Misc::generateWaveform(
-                             mParent->mWaveform, (float)fmod(mParent->mFreq * (float)mOffset, 1.0f)) *
-                         mParent->mADSR.val(mT, 10000000000000.0f);
-            float f = mParent->mFreq * (float)mOffset;
+                             mParent->mWaveform, (double)fmod(mParent->mFreq * (double)mOffset, 1.0)) *
+                         mParent->mADSR.val(mT, 10000000000000.0);
+            double f = mParent->mFreq * (double)mOffset;
             for (int j = 0; j < 3; j++)
             {
                 f *= 2;
                 aBuffer[i] += SoLoud::Misc::generateWaveform(
-                                  mParent->mWaveform, (float)fmod(mParent->mSuperwaveDetune * f, 1.0f)) *
-                              mParent->mADSR.val(mT, 10000000000000.0f) * mParent->mSuperwaveScale;
+                                  mParent->mWaveform, (double)fmod(mParent->mSuperwaveDetune * f, 1.0)) *
+                              mParent->mADSR.val(mT, 10000000000000.0) * mParent->mSuperwaveScale;
             }
             mOffset++;
             mT += d;
@@ -79,8 +79,8 @@ bool BasicwaveInstance::hasEnded()
 Basicwave::Basicwave(
     SoLoud::Soloud::WAVEFORM waveform,
     bool superWave,
-    float scale,
-    float detune)
+    double scale,
+    double detune)
 {
     setSamplerate(44100);
     setWaveform(waveform);
@@ -94,23 +94,23 @@ Basicwave::~Basicwave()
     stop();
 }
 
-void Basicwave::setScale(float aScale)
+void Basicwave::setScale(double aScale)
 {
     mSuperwaveScale = aScale;
 }
 
-void Basicwave::setDetune(float aDetune)
+void Basicwave::setDetune(double aDetune)
 {
     mSuperwaveDetune = aDetune;
 }
 
-void Basicwave::setSamplerate(float aSamplerate)
+void Basicwave::setSamplerate(double aSamplerate)
 {
     mBaseSamplerate = aSamplerate;
-    mFreq = (float)(440 / mBaseSamplerate);
+    mFreq = (double)(440 / mBaseSamplerate);
 }
 
-void Basicwave::setFreq(float aFreq)
+void Basicwave::setFreq(double aFreq)
 {
     mFreq = aFreq / mBaseSamplerate;
 }

--- a/src/synth/basic_wave.h
+++ b/src/synth/basic_wave.h
@@ -34,7 +34,7 @@ class BasicwaveInstance : public SoLoud::AudioSourceInstance
 {
 	Basicwave *mParent;
 	int mOffset;
-	float mT;
+	double mT;
 
 public:
 	BasicwaveInstance(Basicwave *aParent);
@@ -46,22 +46,22 @@ class Basicwave : public SoLoud::AudioSource
 {
 public:
 	ADSR mADSR;
-	float mFreq;
-	float mSuperwaveScale;
-	float mSuperwaveDetune;
+	double mFreq;
+	double mSuperwaveScale;
+	double mSuperwaveDetune;
 	int mWaveform;
 	bool mSuperwave;
 	Basicwave(
 		SoLoud::Soloud::WAVEFORM waveform,
 		bool superWave,
-		float scale,
-		float detune);
+		double scale,
+		double detune);
 	virtual ~Basicwave();
-	void setScale(float aScale);
-	void setDetune(float aDetune);
-	void setSamplerate(float aSamplerate);
+	void setScale(double aScale);
+	void setDetune(double aDetune);
+	void setSamplerate(double aSamplerate);
 	void setWaveform(int aWaveform);
-	void setFreq(float aFreq);
+	void setFreq(double aFreq);
 	void setSuperWave(bool aSuperwave);
 	virtual SoLoud::AudioSourceInstance *createInstance();
 };

--- a/src/synth/soloud_adsr.h
+++ b/src/synth/soloud_adsr.h
@@ -30,17 +30,17 @@ freely, subject to the following restrictions:
 class ADSR
 {
 public:
-	float mA, mD, mS, mR;
+	double mA, mD, mS, mR;
 
 	ADSR()
 	{
-		mA = 0.0f;
-		mD = 0.0f;
-		mS = 1.0f;
-		mR = 0.0f;
+		mA = 0.0;
+		mD = 0.0;
+		mS = 1.0;
+		mR = 0.0;
 	}
 
-	ADSR(float aA, float aD, float aS, float aR)
+	ADSR(double aA, double aD, double aS, double aR)
 	{
 		mA = aA;
 		mD = aD;
@@ -48,7 +48,7 @@ public:
 		mR = aR;
 	}
 
-	float val(float aT, float aRelTime)
+	double val(double aT, double aRelTime)
 	{
 		if (aT < mA)
 		{
@@ -57,7 +57,7 @@ public:
 		aT -= mA;
 		if (aT < mD)
 		{
-			return 1.0f - ((aT / mD)) * (1.0f - mS);
+			return 1.0 - ((aT / mD)) * (1.0 - mS);
 		}
 		aT -= mD;
 		if (aT < aRelTime)
@@ -65,9 +65,9 @@ public:
 		aT -= aRelTime;
 		if (aT >= mR)
 		{
-			return 0.0f;
+			return 0.0;
 		}
-		return (1.0f - aT / mR) * mS;
+		return (1.0 - aT / mR) * mS;
 	}
 };
 


### PR DESCRIPTION
## Description

fix #129 
fix #128
fix #130

## Type of Change

> When changing the frequency of waveform sounds using the flutter_soloud package, after a while, some background frequencies are heard along with the original frequency.

The waveform generation (on C+ side) used float numbers, but higher precision was needed to compute the waveform. Changing to `double`s fixed the issue!

Minor changes for the other 2 issues that fix compiling on iOS.

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
