### PR TITLE
fix: loadAsset future does not fail when an error loading the file occurs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### 2.1.7 ()
+### 2.1.7 (29 Oct 2024)
 - added `listPlaybackDevices` to get all the OS output devices available.
 - added `deviceId` parameter to the `init()` method. You can choose which device is delegated to output the audio.
-- added `changeDevice` method to change the playback device on-the-fly.
+- added `changeDevice` method to change the output playback device on-the-fly.
+- fix: now throws when loading a file that might be corrupt #145.
 
 ### 2.1.6 (17 Oct 2024)
 - fixed a bug that caused an error when loading a sound more than twice.

--- a/lib/src/exceptions/exceptions_from_cpp.dart
+++ b/lib/src/exceptions/exceptions_from_cpp.dart
@@ -31,7 +31,8 @@ class SoLoudFileLoadFailedException extends SoLoudCppException {
   const SoLoudFileLoadFailedException([super.message]);
 
   @override
-  String get description => 'The file was found, but could not be loaded '
+  String get description => 'File found, but could not be loaded! '
+      'Could be a permission error or the file is corrupted. '
       '(on the C++ side).';
 }
 

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -475,6 +475,12 @@ interface class SoLoud {
           final completeFileName = result['completeFileName'] as String;
           final hash = result['hash'] as int;
 
+          if (hash == 0) {
+            loadedFileCompleters[result['completeFileName']]
+                ?.completeError(SoLoudCppException.fromPlayerError(error));
+            return;
+          }
+
           final newSound = AudioSource(SoundHash(hash));
           final alreadyLoaded = _activeSounds
                   .where((sound) => sound.soundHash == newSound.soundHash)
@@ -496,6 +502,8 @@ interface class SoLoud {
               _activeSounds.add(newSound);
             }
           } else {
+            loadedFileCompleters[result['completeFileName']]
+                ?.completeError(SoLoudCppException.fromPlayerError(error));
             throw SoLoudCppException.fromPlayerError(error);
           }
           loadedFileCompleters[result['completeFileName']]?.complete(newSound);
@@ -535,6 +543,7 @@ interface class SoLoud {
   /// Returns the new sound as [AudioSource].
   ///
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
+  /// Throws [SoLoudFileLoadFailedException] if the file could not be loaded.
   ///
   /// If the file is already loaded, this is a no-op (but a warning
   /// will be produced in the log).
@@ -631,6 +640,7 @@ interface class SoLoud {
   /// Throws a [SoLoudTemporaryFolderFailedException] if there was a problem
   /// creating the temporary file that the asset will be copied to.
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
+  /// Throws [SoLoudFileLoadFailedException] if the file could not be loaded.
   ///
   /// Returns the new sound as [AudioSource].
   ///
@@ -673,6 +683,7 @@ interface class SoLoud {
   /// Throws a [SoLoudTemporaryFolderFailedException] if there was a problem
   /// creating the temporary file that the asset will be copied to.
   /// Throws [SoLoudNotInitializedException] if the engine is not initialized.
+  /// Throws [SoLoudFileLoadFailedException] if the file could not be loaded.
   ///
   /// Returns the new sound as [AudioSource].
   ///


### PR DESCRIPTION
## Description

fixes #145

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
