### PR TITLE
fix: Call `loadMem` will crash the application #174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+### 3.0.0-pre.1 (3 Feb 2025)
+- fix: Call `loadMem` will crash the application #174.
+
 ### 3.0.0-pre.0 (2 Feb 2025)
 - fix: clicks and pops when changing waveform frequency #156.
 - added `Limiter` and `Compressor` filters (see `example/lib/filters/`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@
   - `s16le` signed 16 bit little endian
   - `s32le` signed 32 bit little endian
   - `f32le` float 32 bit little endian
-  - `opus` Opus codec compressed audio with Ogg container. Usefull for streaming from the Web (ie using OpenAI APIs).
+  - `opus` Opus codec compressed audio with Ogg container. Useful for streaming from the Web (ie using OpenAI APIs).
 - fixed Web Worker initialization non fatal error that could occur on Web.
 - fixed sound distortion using single pitchShift filter and changing relative play speed #154.
 - fixed the use of `LoadMode.disk` on the Web platform which in some cases caused the `allInstancesFinished` event to not be emitted.
 - improved performance on Web, MacOS and iOS.
-- get wave and FFT sample is now simpler and faster.
+- get wave and FFT samples is now simpler and faster.
 - To avoid future incompatibilities when using other WASM compiled plugins, it is now necessary to add a new script to `index.html`:
   ```
   <script src="assets/packages/flutter_soloud/web/libflutter_soloud_plugin.js" defer></script>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A low-level audio plugin for Flutter,
   mainly meant for games and immersive apps.
   Based on the SoLoud (C++) audio engine.
-version: 3.0.0-pre.0
+version: 3.0.0-pre.1
 issue_tracker: https://github.com/alnitak/flutter_soloud/issues
 homepage: https://github.com/alnitak/flutter_soloud
 maintainer: Marco Bavagnoli (@lildeimos)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -302,7 +302,7 @@ PlayerErrors Player::loadMem(
     {
         newSound.get()->sound = std::make_unique<SoLoud::Wav>();
         newSound.get()->soundType = TYPE_WAV;
-        result = static_cast<SoLoud::Wav *>(newSound.get()->sound.get())->loadMem(mem, length, false, true);
+        result = static_cast<SoLoud::Wav *>(newSound.get()->sound.get())->loadMem(mem, length, true, true);
     }
     else
     {

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -82,8 +82,12 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # in bindings.cpp
 add_compile_definitions(LIBOPUS_OGG_AVAILABLE)
 
-# target_compile_options("${PLUGIN_NAME}" PRIVATE -Wall -Wno-error -fPIC) #  -ldl -lpthread -lm
-target_compile_options("${PLUGIN_NAME}" PRIVATE "/WX-")
+target_compile_options(${PLUGIN_NAME} PRIVATE 
+    /W4     # Warning level 4
+    /WX-    # Disable warnings as errors
+    /arch:SSE2  # Enable SSE2 instructions
+    /arch:SSE3  # Enable SSE3 instructions
+)
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 set(flutter_soloud_bundled_libraries


### PR DESCRIPTION
## Description

a crash happened when calling `loadMem` using `LoadMode.memory` on Windows.

This fixes #174

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
