### PR TITLE
Use native controller call to check ready state.

### DIFF
--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -361,7 +361,7 @@ interface class SoLoud {
       /// get the visualization flag from the player on C side.
       /// Eventually we can set this as a parameter during the
       /// initialization with some other parameters like `sampleRate`
-      _isVisualizationEnabled = getVisualizationEnabled();
+      _isVisualizationEnabled = _controller.soLoudFFI.getVisualizationEnabled();
 
       // Initialize [SoLoudLoader]
       _loader.automaticCleanup = automaticCleanup;


### PR DESCRIPTION
Closes #177

## Description

getVisualizationEnabled() relied on a complex path to check ready state of engine during dart init procedure. Instead, we can call the native binding to the C function which should expose our engine initialization state truthfully.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
