### PR TITLE
Fix error message on missing libogg

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 if (LIBOGG_LIBRARY)
     message("libogg found: ${LIBOGG_LIBRARY}")
 else()
-    message(WARNING "libopus not found")
+    message(WARNING "libogg not found")
 endif()
 
 if (LIBOPUS_LIBRARY AND LIBOGG_LIBRARY)


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The error message when libogg was missing referenced libopus instead. The error message now matches the error.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
