### PR TITLE
log maxActiveVoiceCountReached with Level.INFO #212

### DIFF
--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -2559,7 +2559,8 @@ interface class SoLoud {
   }
 
   /// Utility method that logs a [Level.SEVERE] message if [playerError]
-  /// is anything other than [PlayerErrors.noError].
+  /// is anything other than [PlayerErrors.noError] or [Level.INFO] if
+  /// the error is [PlayerErrors.maxActiveVoiceCountReached].
   ///
   /// Optionally takes a [from] string, so that it can construct messages
   /// with more context:
@@ -2578,7 +2579,8 @@ interface class SoLoud {
       return;
     }
 
-    if (!_log.isLoggable(Level.SEVERE)) {
+    if (!_log.isLoggable(Level.SEVERE) &&
+        playerError != PlayerErrors.maxActiveVoiceCountReached) {
       // Do not do extra work if the logger isn't listening.
       return;
     }
@@ -2588,6 +2590,10 @@ interface class SoLoud {
       strBuf.write('$from: ');
     }
     strBuf.write(playerError.toString());
-    _log.severe(strBuf.toString());
+    if (playerError == PlayerErrors.maxActiveVoiceCountReached) {
+      _log.info(strBuf.toString());
+    } else {
+      _log.severe(strBuf.toString());
+    }
   }
 }

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -2579,9 +2579,13 @@ interface class SoLoud {
       return;
     }
 
-    if (!_log.isLoggable(Level.SEVERE) &&
-        playerError != PlayerErrors.maxActiveVoiceCountReached) {
-      // Do not do extra work if the logger isn't listening.
+    // Do not do extra work if the logger isn't listening
+    // to the appropriate level.
+    final logLevel = playerError == PlayerErrors.maxActiveVoiceCountReached
+        ? Level.INFO
+        : Level.SEVERE;
+
+    if (!_log.isLoggable(logLevel)) {
       return;
     }
 

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -2594,10 +2594,6 @@ interface class SoLoud {
       strBuf.write('$from: ');
     }
     strBuf.write(playerError.toString());
-    if (playerError == PlayerErrors.maxActiveVoiceCountReached) {
-      _log.info(strBuf.toString());
-    } else {
-      _log.severe(strBuf.toString());
-    }
+    _log.log(logLevel, strBuf.toString());
   }
 }


### PR DESCRIPTION
## Description

Fixes #212

`PlayerErrors.maxActiveVoiceCountReached` should log with `Level.INFO` instead of `Level.SEVERE`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
