### PR TITLE
[MacOS]: build failed with XCode 16.3

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
         },
         {
             "label": "compile linux debug",
-            "command": "cd ${workspaceFolder}/example; flutter build linux -t lib/audio_data/audio_data.dart --debug",
+            "command": "cd ${workspaceFolder}/example; flutter build linux -t lib/main.dart --debug",
             "type": "shell"
         },
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.1.4 (6 Apr 2025)
+- fix building issue with XCode 16.3 #217
+
 ### 3.1.3 (31 Mar 2025)
 - fix `listPlaybackDevices` on Web #214
 - log `maxActiveVoiceCountReached` exception with Level.INFO #212

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,7 +45,5 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Used to capture audio for flutter_soloud plugin</string>
 </dict>
 </plist>

--- a/example/macos/Runner/Info.plist
+++ b/example/macos/Runner/Info.plist
@@ -28,7 +28,5 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Used to capture audio for flutter_soloud plugin</string>
 </dict>
 </plist>

--- a/macos/flutter_soloud.podspec
+++ b/macos/flutter_soloud.podspec
@@ -45,8 +45,8 @@ Flutter audio plugin using SoLoud library and FFI
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
     "CLANG_CXX_LIBRARY" => "libc++",
     'OTHER_LDFLAGS' => disable_opus_ogg ? '' : "-L#{local_lib_path} -logg -lopus",
-    'OTHER_CFLAGS' => '-msse -msse2 -msse3 -msse4.1 -O3 -ffast-math -flto',
-    'OTHER_CPLUSPLUSFLAGS' => '-msse -msse2 -msse3 -msse4.1 -O3 -ffast-math -flto',
+    'OTHER_CFLAGS' => "-O3 -ffast-math -flto",
+    'OTHER_CPLUSPLUSFLAGS' => "-O3 -ffast-math -flto",
     'VALID_ARCHS' => 'x86_64 arm64',
    }
    

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A low-level audio plugin for Flutter,
   mainly meant for games and immersive apps.
   Based on the SoLoud (C++) audio engine.
-version: 3.1.3
+version: 3.1.4
 homepage: https://github.com/alnitak/flutter_soloud
 maintainer: Marco Bavagnoli (@lildeimos)
 platforms:

--- a/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
+++ b/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
@@ -40,13 +40,13 @@ namespace SoLoud
 #define MINIAUDIO_IMPLEMENTATION
 // // #define MA_NO_NULL
 // #define MA_NO_DECODING
-// #define MA_NO_WAV
-// #define MA_NO_FLAC
-// #define MA_NO_MP3
-// #define MA_NO_AUTOINITIALIZATION
-// #define MA_NO_VORBIS
-// #define MA_NO_OPUS
-// #define MA_NO_MIDI
+#define MA_NO_WAV
+#define MA_NO_FLAC
+#define MA_NO_MP3
+#define MA_NO_AUTOINITIALIZATION
+#define MA_NO_VORBIS
+#define MA_NO_OPUS
+#define MA_NO_MIDI
 
 // Seems that on miniaudio there is still an issue when uninitializing the device
 // addressed by this issue: https://github.com/mackron/miniaudio/issues/466


### PR DESCRIPTION
## Description

Fixes #217

Removed linking flags from SIMD instructions from iOS and MacOS .podspec file.


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
