### PR TITLE
fix `listPlaybackDevices` fails to retrieve devices when the device prefix contains Chinese characters

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -244,7 +244,7 @@ extern "C"
             /// to be sure.
             for (int n = 0; n < 5; n++)
             {
-                if (d[i].name[n] < 0x20)
+                if (d[i].name[n] < 0x20 && d[i].name[n] >= 0)
                     hasSpecialChar = true;
             }
             if (strlen(d[i].name) <= 5 || hasSpecialChar)


### PR DESCRIPTION
UTF-8 or other character sets may use the high - order 1 of ASCII (8 - bit). When the type of d[i].name[n] is unsigned char and the value is negative, it will be considered to contain special characters and thus filtered out. However, they are legitimate audio devices.

## Description

related to #226

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
