### PR TITLE
fix win: force CMakeLists to build the plugin in release mode even in debug mode

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.3"
   file_picker:
     dependency: "direct main"
     description:
@@ -108,7 +108,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.10"
+    version: "3.1.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -376,10 +376,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "329edf97fdd893e0f1e3b9e88d6a0e627128cc17cc316a8d67fda8f1451178ba"
+      sha256: daf97c9d80197ed7b619040e86c8ab9a9dad285e7671ee7390f9180cc828a51e
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "5.10.1"
   xdg_directories:
     dependency: transitive
     description:
@@ -389,5 +389,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -104,12 +104,53 @@ else()
     add_definitions(-DNO_OPUS_OGG_LIBS)
 endif()
 
-target_compile_options(${PLUGIN_NAME} PRIVATE 
-    /W4     # Warning level 4
+if(MSVC)
+  # Force optimize flags for all configurations
+  string(REPLACE "/O2" "/Ox" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "/Ob1" "/Ob2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+  string(REPLACE "/Od" "/Ox" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  string(REPLACE "/Od" "/Ox" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  
+  # Remove RTC1 from debug flags
+  string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  
+  # Use static runtime for all configurations
+  foreach(CONFIG DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+    string(REPLACE "/MD" "/MT" CMAKE_CXX_FLAGS_${CONFIG} "${CMAKE_CXX_FLAGS_${CONFIG}}")
+    string(REPLACE "/MDd" "/MT" CMAKE_CXX_FLAGS_${CONFIG} "${CMAKE_CXX_FLAGS_${CONFIG}}")
+  endforeach()
+
+  # Advanced optimization flags
+  set(OPTIMIZATION_FLAGS
+    /GL     # Whole program optimization
+    /Gy     # Function-level linking
+    /Oi     # Generate intrinsic functions
+    /Ot     # Favor fast code
+    /Ox     # Full optimization
+    /fp:fast # Fast floating-point model
+    /arch:AVX2  # Use AVX2 instructions
+    /Qpar   # Auto-parallelize loops
+    /O2     # Maximize speed
+    /RTC-   # Disable runtime checks explicitly
+  )
+
+  # Apply optimization flags to all configurations
+  foreach(FLAG ${OPTIMIZATION_FLAGS})
+    target_compile_options(${PLUGIN_NAME} PRIVATE ${FLAG})
+  endforeach()
+
+  # Linker optimization flags
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LTCG /OPT:REF /OPT:ICF")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LTCG /OPT:REF /OPT:ICF")
+
+  # Replace existing compile options with optimized ones
+  target_compile_options(${PLUGIN_NAME} PRIVATE 
+    /W4     # Warning level 4 
     /WX-    # Disable warnings as errors
-    /arch:SSE2  # Enable SSE2 instructions
-    /arch:SSE3  # Enable SSE3 instructions
-)
+    ${OPTIMIZATION_FLAGS}
+  )
+endif()
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 set(flutter_soloud_bundled_libraries


### PR DESCRIPTION
## Description

The plugin in Windows is not always compiled in release mode. This implies poor performaces when the user build apps in debug mode.

This fix force the plugin to be built always in release mode.

For example, loading 12 mp3 files before the fix, it took about 11 seconds and in release about 3. Now loading files take always about 3 seconds.


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
