### PR TITLE
Fix build on iOS, build with 16K align on Android, seek for `released` BufferStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 #### 3.2.2 (16 Jul 2025)
 - OGG is now also supported using `readSamplesFrom*` methods.
-- fix getPosition and bufferirg for released buffer.
+- fix getPosition and buffering for released buffer.
 
 #### 3.2.1 (28 Jun 2025)
 - fix #104, #245, #249. It is now possible to use a 3rd party plugin like `audio_session` to manage audio context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 3.2.3 (3 Aug 2025)
+- fix 16 KB native library alignment on Android #248
+- fix build issue on iOS and macOS #265 #266
+- fix: the `seek` method was causing inconsistent behavior when using `BufferStream` in `BufferingType.released` mode. It is now supported in `BufferingType.preserved` mode.
+
 #### 3.2.2 (16 Jul 2025)
 - OGG is now also supported using `readSamplesFrom*` methods.
 - fix getPosition and bufferirg for released buffer.

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -95,12 +95,10 @@ else()
     add_definitions(-DNO_OPUS_OGG_LIBS)
 endif()
 
-# target_compile_definitions(flutter_soloud PUBLIC DART_SHARED_LIB)
-
 # Support Android 15 16k page size
-# target_link_options(flutter_soloud PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options("${PLUGIN_NAME}" PRIVATE "-Wl,-z,max-page-size=16384")
 
-target_compile_options("${PLUGIN_NAME}" PRIVATE -z max-page-size=16384 -Wall -Wno-error -fPIC -O3) #  -ldl -lpthread -lm
+target_compile_options("${PLUGIN_NAME}" PRIVATE -Wall -Wno-error -fPIC -O3) #  -ldl -lpthread -lm
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 set(flutter_soloud_bundled_libraries

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>Explain why your app uses music</string>
 </dict>
 </plist>

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -32,10 +32,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   audio_session: eaca2512cf2b39212d724f35d11f46180ad3a33e
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
-  flutter_soloud: 83e9cb3d6ac8e636f6280b0ce4deda5d66e0fb02
+  flutter_soloud: 3edb2bae1e4f6312002cde60080f80c608ea57a3
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
 
-PODFILE CHECKSUM: 5e895c4e74302f01a7051c77c78271c4826bc78a
+PODFILE CHECKSUM: cb21593040aa62e3ddedef3470f5f0e3c088e0c9
 
 COCOAPODS: 1.16.2

--- a/example/macos/Runner/DebugProfile.entitlements
+++ b/example/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      sha256: ef9908739bdd9c476353d6adff72e88fd00c625f5b959ae23f7567bd5137db0a
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.7"
+    version: "10.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -116,7 +116,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.1"
+    version: "3.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   cupertino_icons: ^1.0.8
   
-  file_picker: ^8.1.2
+  file_picker: ^10.2.0
 
   flutter:
     sdk: flutter

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -93,7 +93,10 @@ enum PlayerErrors {
   maxActiveVoiceCountReached(26),
 
   /// Trying to get time consumed from wrong buffer type.
-  wrongBufferTypeToAskForTimeConsumed(27);
+  wrongBufferTypeToAskForTimeConsumed(27),
+
+  /// BufferStream with released buffer type cannot be seeked!
+  bufferStreamWithReleasedBufferTypeCannotBeSeeked(28);
 
   const PlayerErrors(this.value);
 
@@ -178,6 +181,8 @@ enum PlayerErrors {
       case PlayerErrors.wrongBufferTypeToAskForTimeConsumed:
         return 'Trying to get time consumed from wrong buffer type. '
             'This is only available for `BufferingType.preserved` buffers.';
+      case PlayerErrors.bufferStreamWithReleasedBufferTypeCannotBeSeeked:
+        return 'BufferStream with released buffer type cannot be seeked.';
     }
   }
 

--- a/lib/src/exceptions/exceptions.dart
+++ b/lib/src/exceptions/exceptions.dart
@@ -128,6 +128,9 @@ abstract class SoLoudCppException extends SoLoudException {
         );
       case PlayerErrors.wrongBufferTypeToAskForTimeConsumed:
         return const SoLoudWrongBufferTypeToAskForTimeConsumedCppException();
+      case PlayerErrors.bufferStreamWithReleasedBufferTypeCannotBeSeeked:
+        // ignore: lines_longer_than_80_chars
+        return const SoLoudBufferStreamWithReleasedBufferTypeCannotBeSeekedCppException();
     }
   }
 

--- a/lib/src/exceptions/exceptions_from_cpp.dart
+++ b/lib/src/exceptions/exceptions_from_cpp.dart
@@ -336,3 +336,17 @@ class SoLoudWrongBufferTypeToAskForTimeConsumedCppException
       'for time consumed. Please use a buffer of type '
       '`BufferingType.released`. (on the C++ side).';
 }
+
+/// The buffer stream with released buffer type cannot be seeked.
+class SoLoudBufferStreamWithReleasedBufferTypeCannotBeSeekedCppException
+    extends SoLoudCppException {
+  /// Creates a new
+  /// [SoLoudBufferStreamWithReleasedBufferTypeCannotBeSeekedCppException].
+  const SoLoudBufferStreamWithReleasedBufferTypeCannotBeSeekedCppException([
+    super.message,
+  ]);
+
+  @override
+  String get description => 'The buffer stream with released buffer type '
+      'cannot be seeked. (on the C++ side).';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A low-level audio plugin for Flutter,
   mainly meant for games and immersive apps.
   Based on the SoLoud (C++) audio engine.
-version: 3.2.2
+version: 3.2.3
 homepage: https://github.com/alnitak/flutter_soloud
 maintainer: Marco Bavagnoli (@lildeimos)
 platforms:

--- a/src/enums.h
+++ b/src/enums.h
@@ -69,6 +69,8 @@ typedef enum PlayerErrors
     maxActiveVoiceCountReached = 26,
     /// Trying to get time consumed from wrong buffer type.
     wrongBufferTypeToAskForTimeConsumed = 27,
+    /// Buffer stream with released buffer type, cannot be seeked.
+    bufferStreamWithReleasedBufferTypeCannotBeSeeked = 28
 } PlayerErrors_t;
 
 /// Possible read sample errors

--- a/src/waveform/miniaudio_libvorbis.cpp
+++ b/src/waveform/miniaudio_libvorbis.cpp
@@ -1,3 +1,5 @@
+#if !defined(NO_OPUS_OGG_LIBS)
+
 #ifndef miniaudio_libvorbis_c
 #define miniaudio_libvorbis_c
 
@@ -738,3 +740,5 @@ ma_decoding_backend_vtable* ma_decoding_backend_libvorbis = NULL;
 #endif
 
 #endif /* miniaudio_libvorbis_c */
+
+#endif /* !defined(MA_NO_LIBVORBIS) */


### PR DESCRIPTION
## Description

- fix 16 KB native library alignment on Android #248
- fix build issue on iOS and macOS #265 #266
- fix: the `seek` method was causing inconsistent behavior when using `BufferStream` in `BufferingType.released` mode. It is now supported in `BufferingType.preserved` mode.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
