### PR TITLE
Fix macos build due to abseil files not found

### DIFF
--- a/macos/flutter_soloud.podspec
+++ b/macos/flutter_soloud.podspec
@@ -38,6 +38,7 @@ Flutter audio plugin using SoLoud library and FFI
       local_include_path,
       '$(PODS_TARGET_SRCROOT)/../src',
       '$(PODS_TARGET_SRCROOT)/../src/soloud/include',
+      '${PODS_ROOT}/abseil',
     ],
     'GCC_PREPROCESSOR_DEFINITIONS' => preprocessor_definitions.join(' '),
     'DEFINES_MODULE' => 'YES', 


### PR DESCRIPTION
## Description

Apply the same fix previously done on iOS to build the MacOS app ([check ios commit](https://github.com/alnitak/flutter_soloud/commit/909ec0f84217fffdb1886aed0a50850c5b1101a3))

Same issue as https://github.com/alnitak/flutter_soloud/issues/271

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
