### PR TITLE
Fix Opus BufferStream end clicks

### DIFF
--- a/src/audiobuffer/opus_stream_decoder.h
+++ b/src/audiobuffer/opus_stream_decoder.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <cstring>
+#include <cstdint>
 
 #ifdef __EMSCRIPTEN__
 // For Web include dirs downloaded from git for build
@@ -37,6 +38,7 @@ private:
     AudioMetadata getMetadata(ogg_packet* packet);
     OpusInfo parseOpusHead(ogg_packet *packet);
     std::vector<float> decodePacket(ogg_packet *packet);
+    bool ensureDecoder(int newSampleRate, int newChannels);
 
     OpusDecoder *decoder;
     int engineSamplerate;
@@ -54,6 +56,9 @@ private:
     // Header parsing state
     bool headerParsed;
     int packetCount;
+    int skipSamplesPending;
+    int64_t totalOutputSamples;
+    int64_t totalSamplesExpected;
 
     OpusInfo opusInfo;
 };


### PR DESCRIPTION
## Description

Fix "click" sound at the end of OGG Opus files (#343):
- fix the BufferStream Opus path so it honors the stream’s `pre_skip`, granule position, and declared sample rate/channels
- root cause: the previous decoder always ran at the engine rate (often 24 kHz), never applied `pre_skip`, and trimmed the PCM buffer to the raw granule position, which cut off real samples and produced the audible click
- solution: recreate the decoder at the stream’s rate/channels, drop the `pre_skip` frames before emitting PCM, and stop only after the expected sample count; the existing 5 ms fade now smooths the true tail instead of hiding a truncation
- confirmed this runs on top of the 3.3.5/3.3.7 audio-quality regression fix (no additional EQ or “dampened” artifacts show up)

✋ WARNING: the changes and commit were generated with the Codex CLI; I’m not an audio-domain expert, so please give this a thorough review! I don't know if all of the changes in the commit are absolutely necessary, but when I tried to simplify the changes or patch less (again, with little personal expertise and the help of AI), the clicks came back. Would be happy if this gets either merged or closed and just used as inspiration for a better fix! 😄 

Also, this doesn't touch the Vorbis stream decoder, which might need its own patch?

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Testing

- streamed multiple short Opus clips through `setBufferStream` + `addAudioDataStream` in my own Flutter app using these changes patched locally to `flutter_soloud`. The clicks at the end of the audio are gone.

Fixes #343 