### PR TITLE
fix: memory leak in FlutterSoLoudFfi.addAudioDataStream

### DIFF
--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -540,6 +540,7 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
       audioChunkPtr,
       audioChunk.length,
     );
+    calloc.free(audioChunkPtr);
     return PlayerErrors.values[e];
   }
 


### PR DESCRIPTION
Fix for [353](https://github.com/alnitak/flutter_soloud/issues/353)

## Description

Added a missing `calloc.free` call.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
