### PR TITLE
[BUG] Fix NO_OPUS_OGG_LIBS in gradle.properties not being used in CMakeLists.txt

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -76,7 +76,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}
 target_link_libraries(${PLUGIN_NAME} PRIVATE ${log-lib} android)
 
 
-if(NOT DEFINED ENV{NO_OPUS_OGG_LIBS})
+if(NOT DEFINED NO_OPUS_OGG_LIBS AND NOT DEFINED ENV{NO_OPUS_OGG_LIBS})
     message("NO_OPUS_OGG_LIBS has not been set. Linking Opus and Ogg libraries!")
 
     # Add FLAC library


### PR DESCRIPTION
Missing "NOT DEFINED NO_OPUS_OGG_LIBS" in the IF check prevents the variable in the gradle.properties to be used in this loc.

## Description
This fixes https://github.com/alnitak/flutter_soloud/issues/354.
I have not been able to use the gradle.properties way to disable opus and vorbis from being added into the APK binaries. 
After prompting claude a few times, it found that in CMakeLists.txt in line 79, it is missing 1 clause which I believe checks the variable in the gradle.properties instead.

## Type of Change

Updated if clause in line 79 to check for "NO_OPUS_OGG_LIBS" variable directly

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
