### PR TITLE
Completer null check

### DIFF
--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -425,8 +425,9 @@ interface class SoLoud {
 
         final exists = loadedFileCompleters.containsKey(key);
         if (exists) {
+          final loadedFileCompleter = loadedFileCompleters[key]!;
           if (hash == 0) {
-            loadedFileCompleters[key]?.completeError(
+            loadedFileCompleter.completeError(
               SoLoudCppException.fromPlayerError(error),
             );
             return;
@@ -455,12 +456,14 @@ interface class SoLoud {
               _activeSounds.add(newSound);
             }
           } else {
-            loadedFileCompleters[key]?.completeError(
+            loadedFileCompleter.completeError(
               SoLoudCppException.fromPlayerError(error),
             );
             throw SoLoudCppException.fromPlayerError(error);
           }
-          loadedFileCompleters[key]?.complete(newSound);
+          if (!loadedFileCompleter.isCompleted) {
+            loadedFileCompleter.complete(newSound);
+          }
         }
       });
     }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
This happens primarily in Windows, but it is possible to overburden the app during tests and get into a `Bad state: Future already completed`.

This primarily happens on Windows when running my integration test suite. The same suite works fine on MacOS. The integration test suite involves calling `init` in setUpAll and `deinit` in tearDownAll. I tried to create a minimal repro repo, but I wasn't able to. My app is a game that involves Flame, Spine, YarnSpinner, and SoLoud, among other things, so I'm assuming that I would need to stress the minimal repro a lot hard to get it to work. I can provide that repo if that would help. Let me know if you have any questions, but this fixes the integration test run in my project.

```
Bad state: Future already completed
  dart:async                                                                                                   _AsyncCompleter.complete
  package:flutter_soloud/src/soloud.dart 463:38                                                                SoLoud._initializeNativeCallbacks.<fn>
  ===== asynchronous gap ===========================
  dart:async                                                                                                   _StreamImpl.listen
  package:flutter_soloud/src/soloud.dart 419:46                                                                SoLoud._initializeNativeCallbacks
  ===== asynchronous gap ===========================
  dart:async                                                                                                   _CustomZone.registerUnaryCallback
  package:flutter_soloud/src/soloud.dart 386:5                                                                 SoLoud._initializeNativeCallbacks
  package:flutter_soloud/src/soloud.dart 262:11                                                                SoLoud.init
  package:danger_world_flame/main.dart 36:27                                                                   init
  ===== asynchronous gap ===========================
  dart:async                                                                                                   _CustomZone.registerUnaryCallback
  package:danger_world_flame/main.dart 27:5                                                                    init
  integration_test\test_helper.dart 19:15                                                                      TestHelper.ensureInitialized
  integration_test\dialogue_history_test.dart 17:24                                                            main.<fn>.<fn>
  ===== asynchronous gap ===========================
  package:stream_channel                                                                                       _GuaranteeSink.add
  c:/Users/antho/AppData/Local/Temp/flutter_tools.5fcaf65e/flutter_test_listener.49cf845f/listener.dart 56:22  main.<fn>

  This test failed after it had already completed.
  Make sure to use a matching library which informs the test runner
  of pending async work.
  dart:async                                                                                                   _AsyncCompleter.complete
  package:flutter_soloud/src/soloud.dart 463:38                                                                SoLoud._initializeNativeCallbacks.<fn>
  ===== asynchronous gap ===========================
  dart:async                                                                                                   _StreamImpl.listen
  package:flutter_soloud/src/soloud.dart 419:46                                                                SoLoud._initializeNativeCallbacks
  ===== asynchronous gap ===========================
  dart:async                                                                                                   _CustomZone.registerUnaryCallback
  package:flutter_soloud/src/soloud.dart 386:5                                                                 SoLoud._initializeNativeCallbacks
  package:flutter_soloud/src/soloud.dart 262:11                                                                SoLoud.init
  package:danger_world_flame/main.dart 36:27                                                                   init
  ===== asynchronous gap ===========================
  dart:async                                                                                                   _CustomZone.registerUnaryCallback
  package:danger_world_flame/main.dart 27:5                                                                    init
  integration_test\test_helper.dart 19:15                                                                      TestHelper.ensureInitialized
  integration_test\dialogue_history_test.dart 17:24                                                            main.<fn>.<fn>
  ===== asynchronous gap ===========================
  package:stream_channel                                                                                       _GuaranteeSink.add
  c:/Users/antho/AppData/Local/Temp/flutter_tools.5fcaf65e/flutter_test_listener.49cf845f/listener.dart 56:22  main.<fn>
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
