### PR TITLE
fix: null check before accessing sound in seek()

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -821,17 +821,17 @@ PlayerErrors Player::seek(SoLoud::handle handle, float time)
         return backendNotInited;
 
     ActiveSound *sound = findByHandle(handle);
+    bool isGroupHandle = soloud.isVoiceGroup(handle);
     
+    if ((sound == nullptr || sound->soundType == TYPE_SYNTH) && !isGroupHandle)
+        return invalidParameter;
+
     // A BufferStream using `release` buffer type cannot use seek.
-    if (sound->soundType == SoundType::TYPE_BUFFER_STREAM &&
+    if (sound != nullptr && sound->soundType == SoundType::TYPE_BUFFER_STREAM &&
         static_cast<SoLoud::BufferStream *>(sound->sound.get())->getBufferingType() == BufferingType::RELEASED)
     {
         return bufferStreamWithReleasedBufferTypeCannotBeSeeked;
     }
-
-    bool isGroupHandle = soloud.isVoiceGroup(handle);
-    if ((sound == nullptr || sound->soundType == TYPE_SYNTH) && !isGroupHandle)
-        return invalidParameter;
 
     SoLoud::result result = soloud.seek(handle, time);
     return (PlayerErrors)result;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

We received crash reports from Crashlytics on iOS (and potentially Android) with this trace:

<img height="300" alt="image" src="https://github.com/user-attachments/assets/4afeb863-f05d-4f17-8d53-fe62694e1e2c" />


I added the null check before accessing the sound.



<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
