### PR TITLE
fix: correct buffering unpause condition to check buffer coverage

### DIFF
--- a/src/audiobuffer/audiobuffer.cpp
+++ b/src/audiobuffer/audiobuffer.cpp
@@ -435,10 +435,11 @@ void BufferStream::checkBuffering(unsigned int afterAddingBytesCount) {
       isPaused = true;
       callOnBufferingCallback(true, handle, currBufferTime);
     } else
-      // This handle has reached [TIME_FOR_BUFFERING]. Unpause it.
-      if (currBufferTime + addedDataTime - mParent->handle[i].bufferingTime >=
-              mBufferingTimeNeeds &&
-          isPaused) {
+    // This handle has reached [TIME_FOR_BUFFERING]. Unpause it.
+	// Only unpause when buffer covers playback position + margin,
+	// not just when new data >= margin (which caused play/pause toggling
+	// when seeking beyond buffered data)
+	if (currBufferTime + addedDataTime >= pos + mBufferingTimeNeeds && isPaused){
         mThePlayer->setPause(handle, false);
         isPaused = false;
         mParent->handle[i].bufferingTime = currBufferTime + addedDataTime;


### PR DESCRIPTION

## Description

    Changed the unpause condition from checking if new data >= margin
    to checking if buffer covers playback position + margin.

    This fixes play/pause toggling when seeking beyond buffered data.
    The old logic would unpause immediately after receiving enough new
    data, even if the playback position was still beyond the buffer.
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
