### PR TITLE
fix: don't use `-msse` on arm64 builds

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -97,7 +97,10 @@ else()
     add_definitions(-DNO_OPUS_OGG_LIBS)
 endif()
 
-target_compile_options("${PLUGIN_NAME}" PRIVATE -Wall -Wno-error -Wno-vla -O2 -msse3 -msse2) #  -ldl -lpthread -lm
+target_compile_options("${PLUGIN_NAME}" PRIVATE -Wall -Wno-error -Wno-vla -O2) #  -ldl -lpthread -lm
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
+    target_compile_options("${PLUGIN_NAME}" PRIVATE -msse3 -msse2)
+endif()
 
 # List of absolute paths to libraries that should be bundled with the plugin.
 set(flutter_soloud_bundled_libraries


### PR DESCRIPTION


## Description

- Fixes #394.
- The CMakeLists were unconditionally using `-msse3 -msse2` options which aren't valid on arm64.
- Those options are now only used for x64 builds and not arm64, fixing builds.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
