### PR TITLE
Harden loader temp directory logic

### DIFF
--- a/lib/src/utils/loader_io.dart
+++ b/lib/src/utils/loader_io.dart
@@ -70,11 +70,12 @@ class SoLoudLoader {
       // Delete files in parallel.
       final results = await Future.wait(files.map(deleteFile));
 
-      if (results.any((success) => !success)) {
-        _log.warning(
-          'Cannot clean up temporary directory. See warnings above.',
-        );
+      final successes = results.where((success) => success == true).length;
+      if (successes < files.length) {
+        _log.warning('Could not delete some files in temporary directory.');
       }
+
+      _log.fine(() => 'Deleted $successes file(s) during cleanUp()');
     } on FileSystemException catch (e, s) {
       _log.warning('Cannot clean up temporary directory: $e', e, s);
     }


### PR DESCRIPTION
## Description

This change addresses a few issues with the current I/O loader:

- It no longer tries to delete the temprorary directory in `cleanUp`. This would lead to the directory being deleted just after initialization when `automaticCleanup` is `true`, which is a catastrophic failure.
- It creates the temporary directory with `recursive: true`, trying to avoid failures when the directory returned by `path_provider` doesn’t yet exist.
- If the directory supplied by `path_provider` fails for any reason (I'm seeing this in the wild on macOS), use the system temp directory instead.
- It adds stack trace to the severe log in initialization, and downgrades cleanup severe logs to warning logs.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
