### PR TITLE
win fix: start miniaudio in its own thread to prevent Windows message pump goes irresponsive

### DIFF
--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <desktop_drop/desktop_drop_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopDropPlugin");
-  desktop_drop_plugin_register_with_registrar(desktop_drop_registrar);
 }

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  desktop_drop
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,13 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import audio_session
-import desktop_drop
 import file_picker
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
-  DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,14 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
-  desktop_drop:
-    dependency: "direct main"
-    description:
-      name: desktop_drop
-      sha256: e70b46b2d61f1af7a81a40d1f79b43c28a879e30a4ef31e87e9c27bea4d784e8
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
   fake_async:
     dependency: transitive
     description:
@@ -224,7 +216,7 @@ packages:
     source: hosted
     version: "1.17.0"
   path:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -372,14 +364,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  universal_platform:
-    dependency: transitive
-    description:
-      name: universal_platform
-      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   vector_math:
     dependency: transitive
     description:

--- a/example/windows/flutter/generated_plugin_registrant.cc
+++ b/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <desktop_drop/desktop_drop_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  DesktopDropPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("DesktopDropPlugin"));
 }

--- a/example/windows/flutter/generated_plugins.cmake
+++ b/example/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  desktop_drop
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Description

**The problem**

After initializing the engine, a plugin like [`desktop_drop`](https://pub.dev/packages/desktop_drop) stops working: no more drag-and-drop is possible.

On Windows, the miniaudio thread interferes with the Windows message pump, which is required by other native plugins. Now, on Windows, the engine runs in its own thread without blocking other message loops. I'm not 100% sure, but it now works for `desktop_drop` and perhaps other similar plugins.

This fixes #409 and maybe #401 also.

- [X] all tests passed

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
