### PR TITLE
remove wasm/js assets for non-web builds

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,13 +63,14 @@ flutter:
 
   assets:
     # These assets are only needed for the web platform.
-    # Waiting for https://github.com/flutter/flutter/issues/65065 and
-    # https://github.com/flutter/flutter/issues/8230 to be addressed.
-    # to make a conditional build.
-    - web/worker.dart.js
-    - web/libflutter_soloud_plugin.js
-    - web/libflutter_soloud_plugin.wasm
-    - web/init_module.dart.js
+    - path: web/worker.dart.js
+      platforms: [web]
+    - path: web/libflutter_soloud_plugin.js
+      platforms: [web]
+    - path: web/libflutter_soloud_plugin.wasm
+      platforms: [web]
+    - path: web/init_module.dart.js
+      platforms: [web]
 
 funding:
   - https://github.com/sponsors/alnitak


### PR DESCRIPTION
## Description

Since https://github.com/flutter/flutter/pull/176393 has landed in Flutter 3.41.0, we can now exclude the wasm/js assets for non-web builds.

I've checked the outputs of `flutter build linux` and `flutter build web` and I can confirm that they are excluded and included respectively.

And this keeps compatibility with older Flutter versions. They build successfully and simply ignore the `platforms` key.

Brings the Linux build of the `example` dir down from 58 MB (Flutter 3.35.0) to 57 MB (Flutter 3.41.5) :)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [X] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
