### PR TITLE
win fix: UTF8 file name conversion was causing crash or file not found

### DIFF
--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -18,7 +18,6 @@
 #include <memory.h>
 #include <memory>
 #include <stdio.h>
-#include <filesystem>
 
 #ifdef __cplusplus
 extern "C" {
@@ -337,11 +336,10 @@ FFI_PLUGIN_EXPORT int isInited() {
     return;
   }
 
-        std::filesystem::path pa = std::filesystem::u8path(completeFileName);
         unsigned int hash = 0;
-        // std::thread loadThread([p, pa, completeFileName, loadIntoMem, hash]()
+        // std::thread loadThread([p, completeFileName, loadIntoMem, hash]()
         //                        {
-        PlayerErrors error = p->loadFile(pa.string(), loadIntoMem, (unsigned int *)&hash);
+        PlayerErrors error = p->loadFile(completeFileName, loadIntoMem, (unsigned int *)&hash);
         // platform_log("LOAD FILE FROM THREAD error: %d  hash: %u\n", error, hash);
         fileLoadedCallback(error, completeFileName, (unsigned int *)&hash, counter);
         // });

--- a/src/soloud/src/core/soloud_file.cpp
+++ b/src/soloud/src/core/soloud_file.cpp
@@ -30,6 +30,12 @@ distribution.
 #include "soloud.h"
 #include "soloud_file.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#endif
+
 namespace SoLoud
 {
 	unsigned int File::read8()
@@ -105,7 +111,22 @@ mFileHandle(fp)
 	{
 		if (!aFilename)
 			return INVALID_PARAMETER;
+#ifdef _WIN32
+		// On Windows, convert UTF-8 to wide string and use _wfopen
+		int wideLen = MultiByteToWideChar(CP_UTF8, 0, aFilename, -1, NULL, 0);
+		if (wideLen == 0)
+			return FILE_NOT_FOUND;
+		wchar_t *wideName = new wchar_t[wideLen];
+		if (MultiByteToWideChar(CP_UTF8, 0, aFilename, -1, wideName, wideLen) == 0)
+		{
+			delete[] wideName;
+			return FILE_NOT_FOUND;
+		}
+		mFileHandle = _wfopen(wideName, L"rb");
+		delete[] wideName;
+#else
 		mFileHandle = fopen(aFilename, "rb");
+#endif
 		if (!mFileHandle)
 			return FILE_NOT_FOUND;
 		return SO_NO_ERROR;

--- a/src/waveform/waveform.cpp
+++ b/src/waveform/waveform.cpp
@@ -9,6 +9,27 @@
 #include <cstring>
 #include <cmath>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+// Helper function to convert UTF-8 to wide string on Windows
+#ifdef _WIN32
+static wchar_t* utf8ToWide(const char* utf8Str)
+{
+    int wideLen = MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, NULL, 0);
+    if (wideLen == 0)
+        return NULL;
+    wchar_t* wideStr = new wchar_t[wideLen];
+    if (MultiByteToWideChar(CP_UTF8, 0, utf8Str, -1, wideStr, wideLen) == 0)
+    {
+        delete[] wideStr;
+        return NULL;
+    }
+    return wideStr;
+}
+#endif
+
 namespace Waveform
 {
     ReadSamplesErrors readSamplesFromDecoder(
@@ -107,7 +128,18 @@ namespace Waveform
         // Check if the file is an OGG file by reading the header
         if (filePath != NULL)
         {
-            FILE *file = fopen(filePath, "rb");
+            FILE *file = NULL;
+#ifdef _WIN32
+            // On Windows, convert UTF-8 to wide string and use _wfopen
+            wchar_t* wideName = utf8ToWide(filePath);
+            if (wideName)
+            {
+                file = _wfopen(wideName, L"rb");
+                delete[] wideName;
+            }
+#else
+            file = fopen(filePath, "rb");
+#endif
             if (file)
             {
                 unsigned char header[4];
@@ -140,9 +172,25 @@ namespace Waveform
         
         // Init the decoder with file or memory
         if (filePath != NULL)
+        {
+#ifdef _WIN32
+            // On Windows, use wide string version for UTF-8 support
+            wchar_t* wideName = utf8ToWide(filePath);
+            if (!wideName)
+            {
+                printf("Failed to convert filename to wide string.\n");
+                return noBackend;
+            }
+            result = ma_decoder_init_file_w(wideName, isOgg ? &decoderConfig : NULL, &decoder);
+            delete[] wideName;
+#else
             result = ma_decoder_init_file(filePath, isOgg ? &decoderConfig : NULL, &decoder);
+#endif
+        }
         else
+        {
             result = ma_decoder_init_memory(buffer, dataSize, isOgg ? &decoderConfig : NULL, &decoder);
+        }
 
         if (result != MA_SUCCESS)
         {
@@ -174,9 +222,25 @@ namespace Waveform
 
             // Re-init with updated config
             if (filePath != NULL)
+            {
+#ifdef _WIN32
+                // On Windows, use wide string version for UTF-8 support
+                wchar_t* wideName = utf8ToWide(filePath);
+                if (!wideName)
+                {
+                    printf("Failed to convert filename to wide string.\n");
+                    return noBackend;
+                }
+                result = ma_decoder_init_file_w(wideName, &decoderConfig, &decoder);
+                delete[] wideName;
+#else
                 result = ma_decoder_init_file(filePath, &decoderConfig, &decoder);
+#endif
+            }
             else
+            {
                 result = ma_decoder_init_memory(buffer, dataSize, &decoderConfig, &decoder);
+            }
 
             if (result != MA_SUCCESS)
             {


### PR DESCRIPTION
## Description

- UTF-8 is converted to UTF-16 for proper file opening that lead `loadFile` to crash or open error with non unicode chars
- `readSamples` had the same problem, but now the miniaudio `ma_decoder_init_file_w` is used instead of `ma_decoder_init_file`

closes #401

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)