### PR TITLE
fix: FFI symbol stripping causing "symbol not found" errors in iOS/macOS when uploading to App Store

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/ios/flutter_soloud.podspec
+++ b/ios/flutter_soloud.podspec
@@ -107,6 +107,9 @@ Flutter audio plugin using SoLoud library and FFI
     'OTHER_LDFLAGS[sdk=iphoneos*]' => "$(inherited) #{user_ldflags_device}",
     'OTHER_LDFLAGS[sdk=iphonesimulator*]' => "$(inherited) #{user_ldflags_sim}",
     'LIBRARY_SEARCH_PATHS' => "$(inherited) \"#{plugin_root}/cmake_build/$(PLATFORM_NAME)\" \"#{plugin_root}/flutter_soloud/libs\"",
+    # Fix for FFI symbol stripping on iOS Release builds
+    'STRIP_STYLE' => 'debugging',
+    'DEBUG_INFORMATION_FORMAT' => 'dwarf-with-dsym',
   }
   
   # Do NOT use vendored_libraries for Xiph libs — it generates non-SDK-conditioned

--- a/ios/flutter_soloud/Package.swift
+++ b/ios/flutter_soloud/Package.swift
@@ -84,6 +84,9 @@ var targets: [Target] = [
         linkerSettings: [
             .linkedFramework("AudioToolbox"),
             .linkedFramework("AVFAudio"),
+            // Fix for FFI symbol stripping on Release builds
+            // These flags ensure FFI symbols are preserved in the app binary
+            .unsafeFlags(["-Xlinker", "-strip_debug_only"], .when(configuration: .release)),
         ]
     )
 ]

--- a/macos/flutter_soloud.podspec
+++ b/macos/flutter_soloud.podspec
@@ -86,6 +86,9 @@ Flutter audio plugin using SoLoud library and FFI
   s.user_target_xcconfig = {
     'OTHER_LDFLAGS' => "$(inherited) #{force_load_lib} #{xiph_flags}",
     'LIBRARY_SEARCH_PATHS' => "$(inherited) \"#{plugin_root}/cmake_build/macosx\" \"#{plugin_root}/libs\"",
+    # Fix for FFI symbol stripping on macOS Release builds
+    'STRIP_STYLE' => 'debugging',
+    'DEBUG_INFORMATION_FORMAT' => 'dwarf-with-dsym',
   }
 
   s.swift_version = '5.0'

--- a/macos/flutter_soloud/Package.swift
+++ b/macos/flutter_soloud/Package.swift
@@ -84,6 +84,9 @@ var targets: [Target] = [
         linkerSettings: [
             .linkedFramework("AudioToolbox"),
             .linkedFramework("AVFAudio"),
+            // Fix for FFI symbol stripping on Release builds
+            // These flags ensure FFI symbols are preserved in the app binary
+            .unsafeFlags(["-Xlinker", "-strip_debug_only"], .when(configuration: .release)),
         ]
     )
 ]


### PR DESCRIPTION
## Description

When users build and upload their apps to App Store Connect, the native FFI symbols (like isInited) are being stripped from the binary in Release builds. This causes runtime errors like:

ArgumentError: Invalid argument(s): Failed to lookup symbol 'isInited': 
dlsym(RTLD_DEFAULT, isInited): symbol not found
The issue only occurs in Release builds (local debug/release builds work fine), which suggests aggressive symbol stripping by the linker.

Before in the doc, was suggested to modify symbol stripping opening the project in Xcode:

<img width="744" height="218" alt="Screenshot 2026-03-29 at 14 38 07" src="https://github.com/user-attachments/assets/523191fa-2920-405b-ae73-e679737cd15c" />


now this should be managed automatically.

fixes #114

## Type of Change

- [X] ✅ Build configuration change