### PR TITLE
fix(init): rebind Dart callbacks after hot restart

### DIFF
--- a/example/tests/tests/all_tests.dart
+++ b/example/tests/tests/all_tests.dart
@@ -3,6 +3,7 @@ import 'all_instances_finished.dart' as all_instances_finished;
 import 'async_multi_load.dart' as async_multi_load;
 import 'asynchronous_deinit.dart' as asynchronous_deinit;
 import 'auto_dispose.dart' as auto_dispose;
+import 'hot_restart_lifecycle.dart' as hot_restart_lifecycle;
 import 'buffer_stream_extended.dart' as buffer_stream_extended;
 import 'buffer_stream_small_mp3.dart' as buffer_stream_small_mp3;
 import 'compressor_filter.dart' as compressor_filter;
@@ -195,5 +196,9 @@ final List<TestEntry> allTests = [
   const TestEntry(
     name: 'BufferStreamSmallMp3',
     run: buffer_stream_small_mp3.testBufferStreamSmallMp3,
+  ),
+  const TestEntry(
+    name: 'HotRestartLifecycle',
+    run: hot_restart_lifecycle.testHotRestartLifecycle,
   ),
 ];

--- a/example/tests/tests/hot_restart_lifecycle.dart
+++ b/example/tests/tests/hot_restart_lifecycle.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_soloud/flutter_soloud.dart';
+import 'package:flutter_soloud/src/bindings/soloud_controller.dart';
+
+import 'common.dart';
+
+/// Test the init/deinit/re-init lifecycle that PR #444 fixes.
+///
+/// After a hot restart the native engine can survive while the Dart isolate's
+/// callback bindings are gone.  [SoLoud.isInitialized] must stay `false` until
+/// callbacks are rebound by a fresh [SoLoud.init] call.  We can't trigger a
+/// real hot restart from an integration test, but we CAN exercise the same
+/// code path: call `init()` when the native player is already alive (which
+/// `init()` treats as the hot-restart recovery branch).
+Future<StringBuffer> testHotRestartLifecycle() async {
+  final buf = StringBuffer();
+
+  // ── 1. Fresh init ───────────────────────────────────────────────────────
+  await SoLoud.instance.init();
+  assert(
+    SoLoud.instance.isInitialized,
+    'isInitialized must be true after init()',
+  );
+  assert(
+    SoLoudController().soLoudFFI.isInited(),
+    'native isInited must be true after init()',
+  );
+  buf.writeln('1. Fresh init: OK');
+
+  // ── 2. deinit clears both sides ─────────────────────────────────────────
+  SoLoud.instance.deinit();
+  assert(
+    !SoLoud.instance.isInitialized,
+    'isInitialized must be false after deinit()',
+  );
+  assert(
+    !SoLoudController().soLoudFFI.isInited(),
+    'native isInited must be false after deinit()',
+  );
+  buf.writeln('2. deinit: OK');
+
+  // ── 3. Clean re-init after full deinit ───────────────────────────────────
+  await SoLoud.instance.init();
+  assert(
+    SoLoud.instance.isInitialized,
+    'isInitialized must be true after re-init()',
+  );
+  buf.writeln('3. Clean re-init: OK');
+
+  // ── 4. Hot-restart recovery: init() while native is still alive ─────────
+  //    This is the actual hot-restart code path (soloud.dart ~line 298).
+  //    When init() detects native is already initialized, it calls
+  //    clearDartCallbackRegistrations() + deinit() internally, then
+  //    re-initializes everything with fresh callbacks.
+  await SoLoud.instance.init();
+  assert(
+    SoLoud.instance.isInitialized,
+    'isInitialized must be true after hot-restart recovery init()',
+  );
+  assert(
+    SoLoudController().soLoudFFI.isInited(),
+    'native isInited must be true after hot-restart recovery init()',
+  );
+  buf.writeln('4. Hot-restart recovery (init while native alive): OK');
+
+  // ── 5. Callbacks work after hot-restart recovery ────────────────────────
+  //    Load a sound and play it — this exercises the voice-ended callback
+  //    path that would crash with stale pointers after a real hot restart.
+  final sound = await loadAsset();
+  final handle = SoLoud.instance.play(sound);
+
+  // The handle must be valid.
+  assert(
+    SoLoudController().soLoudFFI.getIsValidVoiceHandle(handle),
+    'handle should be valid after play()',
+  );
+
+  // Let it play briefly, then stop — the voice-ended callback fires.
+  await delay(200);
+  await SoLoud.instance.stop(handle);
+  await delay(100);
+
+  assert(
+    !SoLoudController().soLoudFFI.getIsValidVoiceHandle(handle),
+    'handle should be invalid after stop()',
+  );
+  buf.writeln('5. Callbacks work after hot-restart recovery: OK');
+
+  // ── 6. Rapid init/deinit/init cycling ───────────────────────────────────
+  SoLoud.instance.deinit();
+  for (var i = 0; i < 5; i++) {
+    await SoLoud.instance.init();
+    assert(SoLoud.instance.isInitialized, 'cycle $i: should be initialized');
+    SoLoud.instance.deinit();
+    assert(
+      !SoLoud.instance.isInitialized,
+      'cycle $i: should not be initialized',
+    );
+  }
+  buf.writeln('6. Rapid init/deinit cycling (5x): OK');
+
+  debugPrint(buf.toString());
+  return buf;
+}

--- a/lib/src/bindings/bindings_player.dart
+++ b/lib/src/bindings/bindings_player.dart
@@ -54,6 +54,10 @@ abstract class FlutterSoLoud {
   @mustBeOverridden
   void disposeNativeCallables();
 
+  /// Used with FFI only to make native forget every Dart callback pointer.
+  @mustBeOverridden
+  void clearDartCallbackRegistrations();
+
   /// Set Dart functions to call when an event occurs.
   ///
   /// On the web, only the `voiceEndedCallback` is supported. On the other

--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -137,10 +137,18 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
 
   @override
   void disposeNativeCallables() {
+    clearDartCallbackRegistrations();
     nativeVoiceEndedCallable?.close();
+    nativeVoiceEndedCallable = null;
     nativeFileLoadedCallable?.close();
+    nativeFileLoadedCallable = null;
     nativeStateChangedCallable?.close();
-    _setDartEventCallback(ffi.nullptr, ffi.nullptr, ffi.nullptr);
+    nativeStateChangedCallable = null;
+  }
+
+  @override
+  void clearDartCallbackRegistrations() {
+    _clearDartCallbackRegistrations();
   }
 
   @override
@@ -184,6 +192,13 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
           DartStateChangedCallbackT,
         )
       >();
+
+  late final _clearDartCallbackRegistrationsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function()>>(
+        'clearDartCallbackRegistrations',
+      );
+  late final _clearDartCallbackRegistrations =
+      _clearDartCallbackRegistrationsPtr.asFunction<void Function()>();
 
   // ////////////////////////////////////////////////
   // Navtive bindings

--- a/lib/src/bindings/bindings_player_web.dart
+++ b/lib/src/bindings/bindings_player_web.dart
@@ -43,6 +43,11 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     /// Nothing to do on web.
   }
 
+  @override
+  void clearDartCallbackRegistrations() {
+    /// Nothing to do on web.
+  }
+
   /// Create the worker in the WASM Module and listen for events coming
   /// from `web/worker.dart.js`
   @override

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -176,6 +176,13 @@ interface class SoLoud {
   /// Whether or not is it possible to ask for wave and FFT data.
   bool _isVisualizationEnabled = false;
 
+  /// Whether this Dart isolate has registered native callbacks.
+  ///
+  /// After a Flutter hot restart, the native engine can survive while the old
+  /// isolate's callback bindings are gone. Until callbacks are rebound, the
+  /// engine must be treated as not ready from Dart.
+  bool _nativeCallbacksInitialized = false;
+
   /// The current status of the engine. This is `true` when the engine
   /// has been initialized and is immediately ready.
   ///
@@ -189,7 +196,8 @@ interface class SoLoud {
   ///
   /// Use [isInitialized] only if you want to check the current status of
   /// the engine synchronously and you don't care that it might be ready soon.
-  bool get isInitialized => _controller.soLoudFFI.isInited();
+  bool get isInitialized =>
+      _nativeCallbacksInitialized && _controller.soLoudFFI.isInited();
 
   /// Backing of [activeSounds].
   final List<AudioSource> _activeSounds = [];
@@ -260,10 +268,8 @@ interface class SoLoud {
     int bufferSize = 2048,
     Channels channels = Channels.stereo,
   }) async {
+    final nativeIsInitialized = _controller.soLoudFFI.isInited();
     _log.finest('init() called');
-
-    // Initialize native callbacks
-    await _initializeNativeCallbacks();
 
     // Making extra sure no state is dangling after a hot-restart.
     assert(
@@ -289,7 +295,7 @@ interface class SoLoud {
     // the developer may have carried out a hot reload which does not imply
     // the release of the native player.
     // Just deinit the engine to be re-inited later.
-    if (isInitialized) {
+    if (nativeIsInitialized) {
       _log.warning(
         'init() called when the native player is already '
         'initialized. This is expected after a hot restart but not '
@@ -297,11 +303,8 @@ interface class SoLoud {
         'a bug in your code. You may have neglected to deinit() SoLoud '
         'during the current lifetime of the app.',
       );
+      _controller.soLoudFFI.clearDartCallbackRegistrations();
       deinit();
-
-      /// Re-initialize native callbacks because the above call to `deinit()`
-      /// has released them.
-      await _initializeNativeCallbacks();
     }
 
     final error = _controller.soLoudFFI.initEngine(
@@ -320,8 +323,14 @@ interface class SoLoud {
       // Initialize [SoLoudLoader]
       _loader.automaticCleanup = automaticCleanup;
 
+      // Register fresh Dart callbacks only after the native player has been
+      // reset and re-initialized.
+      await _initializeNativeCallbacks();
+      _nativeCallbacksInitialized = true;
+
       await _loader.initialize();
     } else {
+      _nativeCallbacksInitialized = false;
       _log.severe('initialize() failed with error: $error');
       throw SoLoudCppException.fromPlayerError(error);
     }
@@ -363,6 +372,7 @@ interface class SoLoud {
   /// or inside "AppLifecycleListener.onExitRequested".
   void deinit() {
     _log.finest('deinit() called');
+    _nativeCallbacksInitialized = false;
     _controller.soLoudFFI.disposeNativeCallables();
     _controller.soLoudFFI.disposeAllSound();
     _controller.soLoudFFI.deinit();

--- a/src/audiobuffer/audiobuffer.cpp
+++ b/src/audiobuffer/audiobuffer.cpp
@@ -233,8 +233,8 @@ PlayerErrors BufferStream::setBufferStream(
   mBufferingTimeNeeds = bufferingTimeNeeds;
   mChannels = pcmFormat.channels;
   mBaseSamplerate = (float)pcmFormat.sampleRate;
-  mOnBufferingCallback = onBufferingCallback;
-  mOnMetadataCallback = onMetadataCallback;
+  mOnBufferingCallback.store(onBufferingCallback);
+  mOnMetadataCallback.store(onMetadataCallback);
   buffer = std::vector<unsigned char>();
   mBuffer.setBufferType(bufferingType);
   mIsBuffering = true;
@@ -458,7 +458,8 @@ void BufferStream::checkBuffering(unsigned int afterAddingBytesCount) {
 }
 
 void BufferStream::callOnMetadataCallback(AudioMetadata &metadata) {
-  if (mOnMetadataCallback != nullptr) {
+  auto metadataCb = mOnMetadataCallback.load();
+  if (metadataCb != nullptr) {
     AudioMetadataFFI ffi = this->convertMetadataToFFI(metadata);
     // metadata.debug();
 #ifdef __EMSCRIPTEN__
@@ -478,14 +479,15 @@ void BufferStream::callOnMetadataCallback(AudioMetadata &metadata) {
         },
         &ffi, mParent->soundHash);
 #else
-    mOnMetadataCallback(ffi);
+    metadataCb(ffi);
 #endif
   }
 }
 
 void BufferStream::callOnBufferingCallback(bool isBuffering,
                                            unsigned int handle, double time) {
-  if (mOnBufferingCallback != nullptr) {
+  auto bufferingCb = mOnBufferingCallback.load();
+  if (bufferingCb != nullptr) {
 #ifdef __EMSCRIPTEN__
     // Call the Dart callback stored on globalThis, if it exists.
     // The `dartOnBufferingCallback_$hash` function is created in
@@ -505,15 +507,15 @@ void BufferStream::callOnBufferingCallback(bool isBuffering,
         },
         isBuffering, handle, time, mParent->soundHash);
 #else
-    mOnBufferingCallback(isBuffering, handle, time);
+    bufferingCb(isBuffering, handle, time);
 #endif
   }
   mIsBuffering = isBuffering;
 }
 
 void BufferStream::clearDartCallbacks() {
-  mOnBufferingCallback = nullptr;
-  mOnMetadataCallback = nullptr;
+  mOnBufferingCallback.store(nullptr);
+  mOnMetadataCallback.store(nullptr);
 }
 
 BufferingType BufferStream::getBufferingType() { return mBuffer.bufferingType; }

--- a/src/audiobuffer/audiobuffer.cpp
+++ b/src/audiobuffer/audiobuffer.cpp
@@ -511,6 +511,11 @@ void BufferStream::callOnBufferingCallback(bool isBuffering,
   mIsBuffering = isBuffering;
 }
 
+void BufferStream::clearDartCallbacks() {
+  mOnBufferingCallback = nullptr;
+  mOnMetadataCallback = nullptr;
+}
+
 BufferingType BufferStream::getBufferingType() { return mBuffer.bufferingType; }
 
 SoLoud::time BufferStream::getLength() {

--- a/src/audiobuffer/audiobuffer.h
+++ b/src/audiobuffer/audiobuffer.h
@@ -45,8 +45,8 @@ public:
   Player *mThePlayer;
   // Used to access the AudioSource this stream belongs to
   ActiveSound *mParent;
-  dartOnBufferingCallback_t mOnBufferingCallback;
-  dartOnMetadataCallback_t mOnMetadataCallback;
+  std::atomic<dartOnBufferingCallback_t> mOnBufferingCallback{nullptr};
+  std::atomic<dartOnMetadataCallback_t> mOnMetadataCallback{nullptr};
   unsigned int autoTypeChannels;
   float autoTypeSamplerate;
   unsigned int mMaxBufferSize;

--- a/src/audiobuffer/audiobuffer.h
+++ b/src/audiobuffer/audiobuffer.h
@@ -86,6 +86,7 @@ public:
   void callOnMetadataCallback(AudioMetadata &metadata);
   void callOnBufferingCallback(bool isBuffering, unsigned int handle,
                                double time);
+  void clearDartCallbacks();
   BufferingType getBufferingType();
   virtual AudioSourceInstance *createInstance();
   

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -14,6 +14,7 @@
 #include <emscripten/emscripten.h>
 #endif
 
+#include <atomic>
 #include <map>
 #include <memory.h>
 #include <memory>
@@ -38,9 +39,10 @@ typedef void (*dartFileLoadedCallback_t)(enum PlayerErrors *, char *completeFile
 typedef void (*dartStateChangedCallback_t)(enum PlayerStateEvents *);
 
 // to be used by `NativeCallable`, these functions must return void.
-void (*dartVoiceEndedCallback)(unsigned int *) = nullptr;
-void (*dartFileLoadedCallback)(enum PlayerErrors *, char *completeFileName, unsigned int *, uint64_t *counter) = nullptr;
-void (*dartStateChangedCallback)(enum PlayerStateEvents *) = nullptr;
+// Atomic so the audio thread can safely snapshot the pointer before calling.
+std::atomic<dartVoiceEndedCallback_t> dartVoiceEndedCallback{nullptr};
+std::atomic<dartFileLoadedCallback_t> dartFileLoadedCallback{nullptr};
+std::atomic<dartStateChangedCallback_t> dartStateChangedCallback{nullptr};
 
 //////////////////////////////////////////////////////////////
 /// WEB WORKER
@@ -127,7 +129,9 @@ FFI_PLUGIN_EXPORT void voiceEndedCallback(unsigned int *handle) {
 #endif
 
   // The `dartVoiceEndedCallback` is not set on Web.
-  if (dartVoiceEndedCallback == nullptr)
+  // Snapshot the atomic pointer so it can't be nulled between check and call.
+  auto voiceEndedCb = dartVoiceEndedCallback.load();
+  if (voiceEndedCb == nullptr)
     return;
   // So, if the handle was already found before (henche the handle is not
   // found), the callback to Dart has been already called. If this is the fist
@@ -137,13 +141,14 @@ FFI_PLUGIN_EXPORT void voiceEndedCallback(unsigned int *handle) {
   // [n] pointer must be deleted in Dart.
   unsigned int *n = (unsigned int *)malloc(sizeof(unsigned int *));
   *n = *handle;
-  dartVoiceEndedCallback(n);
+  voiceEndedCb(n);
 }
 
     /// The callback to monitor when a file is loaded.
     void fileLoadedCallback(enum PlayerErrors error, char *completeFileName, unsigned int *hash, uint64_t counter)
     {
-        if (dartFileLoadedCallback == nullptr)
+        auto fileLoadedCb = dartFileLoadedCallback.load();
+        if (fileLoadedCb == nullptr)
             return;
         // [e,name,n] pointers must be deleted on Dart.
         PlayerErrors *e = (PlayerErrors *)malloc(sizeof(PlayerErrors *));
@@ -153,14 +158,15 @@ FFI_PLUGIN_EXPORT void voiceEndedCallback(unsigned int *handle) {
         *n = *hash;
         uint64_t *ts = (uint64_t *)malloc(sizeof(uint64_t *));
         *ts = counter;
-        dartFileLoadedCallback(e, name, n, ts);
+        fileLoadedCb(e, name, n, ts);
     }
 
 void stateChangedCallback(unsigned int state) {
+  auto stateChangedCb = dartStateChangedCallback.load();
+  if (stateChangedCb == nullptr) return;
   PlayerStateEvents *type = (PlayerStateEvents *)malloc(sizeof(unsigned int *));
   *type = (PlayerStateEvents)state;
-  if (dartStateChangedCallback != nullptr)
-    dartStateChangedCallback(type);
+  stateChangedCb(type);
 }
 
 /// Set a Dart functions to call when an event occurs.
@@ -169,18 +175,18 @@ FFI_PLUGIN_EXPORT void
 setDartEventCallback(dartVoiceEndedCallback_t voice_ended_callback,
                      dartFileLoadedCallback_t file_loaded_callback,
                      dartStateChangedCallback_t state_changed_callback) {
-  dartVoiceEndedCallback = voice_ended_callback;
-  dartFileLoadedCallback = file_loaded_callback;
-  dartStateChangedCallback = state_changed_callback;
+  dartVoiceEndedCallback.store(voice_ended_callback);
+  dartFileLoadedCallback.store(file_loaded_callback);
+  dartStateChangedCallback.store(state_changed_callback);
 }
 
 FFI_PLUGIN_EXPORT void clearDartCallbackRegistrations() {
   std::lock_guard<std::mutex> guard_init(init_deinit_mutex);
   std::lock_guard<std::mutex> guard_load(loadMutex);
 
-  dartVoiceEndedCallback = nullptr;
-  dartFileLoadedCallback = nullptr;
-  dartStateChangedCallback = nullptr;
+  dartVoiceEndedCallback.store(nullptr);
+  dartFileLoadedCallback.store(nullptr);
+  dartStateChangedCallback.store(nullptr);
 
   if (player.get() != nullptr) {
     player.get()->clearDartCallbackRegistrations();

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -174,6 +174,19 @@ setDartEventCallback(dartVoiceEndedCallback_t voice_ended_callback,
   dartStateChangedCallback = state_changed_callback;
 }
 
+FFI_PLUGIN_EXPORT void clearDartCallbackRegistrations() {
+  std::lock_guard<std::mutex> guard_init(init_deinit_mutex);
+  std::lock_guard<std::mutex> guard_load(loadMutex);
+
+  dartVoiceEndedCallback = nullptr;
+  dartFileLoadedCallback = nullptr;
+  dartStateChangedCallback = nullptr;
+
+  if (player.get() != nullptr) {
+    player.get()->clearDartCallbackRegistrations();
+  }
+}
+
 //////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -891,6 +891,24 @@ void Player::disposeAllSound()
     // Sounds (and their filters) are destroyed here when soundsToDestroy goes out of scope
 }
 
+void Player::clearDartCallbackRegistrations()
+{
+    setVoiceEndedCallback(nullptr);
+    setStateChangedCallback(nullptr);
+
+    std::lock_guard<std::recursive_mutex> lock(sounds_mutex);
+    for (auto &sound : sounds)
+    {
+        if (sound != nullptr &&
+            sound->soundType == SoundType::TYPE_BUFFER_STREAM &&
+            sound->sound != nullptr)
+        {
+            static_cast<SoLoud::BufferStream *>(sound->sound.get())
+                ->clearDartCallbacks();
+        }
+    }
+}
+
 bool Player::getLooping(unsigned int handle)
 {
     return soloud.getLooping(handle);

--- a/src/player.h
+++ b/src/player.h
@@ -262,6 +262,9 @@ public:
   /// @brief Dispose all sounds already loaded.
   void disposeAllSound();
 
+  /// @brief Clear every native->Dart callback pointer held by the player.
+  void clearDartCallbackRegistrations();
+
   /// @brief Ask whether a sound is set to loop or not.
   bool getLooping(unsigned int handle);
 


### PR DESCRIPTION
## Description

Fixes a hot-restart bug where `SoLoud.isInitialized` could report that the engine was ready even though the current Dart isolate had not rebound its native callbacks yet.

After a Flutter hot restart, the native SoLoud engine survives but the old Dart isolate's callback bindings are gone. If app code skipped `init()` because `isInitialized` returned `true`, the next native callback would hit a stale Dart pointer and crash.

### What changed

**Dart side** (first commit):
- Track whether native callbacks have been registered for the current Dart isolate (`_nativeCallbacksInitialized`)
- `isInitialized` now requires both native engine state AND current-isolate callback readiness
- `init()` detects when native is already alive (hot-restart case), clears stale callback registrations, tears down, and re-initializes with fresh callbacks

**C++ side** (second commit):
- Global callback pointers (`dartVoiceEndedCallback`, `dartFileLoadedCallback`, `dartStateChangedCallback`) and per-stream callback pointers (`mOnBufferingCallback`, `mOnMetadataCallback`) are now `std::atomic` — prevents TOCTOU races where the audio thread reads a pointer that another thread is nulling
- All callback call sites use snapshot-then-call: `auto cb = ptr.load(); if (cb) cb(args);`
- Fixed a memory leak in `stateChangedCallback` where `malloc` was called before the null check

**Test** (second commit):
- Added `HotRestartLifecycle` on-device integration test matching the project's `example/tests/tests/` pattern
- Exercises: fresh init, deinit, clean re-init, hot-restart recovery (init while native is still alive), post-recovery callback verification (load + play + stop), and rapid init/deinit cycling (5x)
- Deleted mock-based unit test that didn't fit the project's test paradigm

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)