### PR TITLE
fix(ffi): retain BufferStream callbacks until disposal

### DIFF
--- a/example/tests/tests/all_tests.dart
+++ b/example/tests/tests/all_tests.dart
@@ -3,6 +3,7 @@ import 'all_instances_finished.dart' as all_instances_finished;
 import 'async_multi_load.dart' as async_multi_load;
 import 'asynchronous_deinit.dart' as asynchronous_deinit;
 import 'auto_dispose.dart' as auto_dispose;
+import 'buffer_stream_callbacks.dart' as buffer_stream_callbacks;
 import 'buffer_stream_extended.dart' as buffer_stream_extended;
 import 'buffer_stream_small_mp3.dart' as buffer_stream_small_mp3;
 import 'compressor_filter.dart' as compressor_filter;
@@ -195,5 +196,9 @@ final List<TestEntry> allTests = [
   const TestEntry(
     name: 'BufferStreamSmallMp3',
     run: buffer_stream_small_mp3.testBufferStreamSmallMp3,
+  ),
+  const TestEntry(
+    name: 'BufferStreamCallbacks',
+    run: buffer_stream_callbacks.testBufferStreamCallbacks,
   ),
 ];

--- a/example/tests/tests/all_tests.dart
+++ b/example/tests/tests/all_tests.dart
@@ -4,7 +4,6 @@ import 'async_multi_load.dart' as async_multi_load;
 import 'asynchronous_deinit.dart' as asynchronous_deinit;
 import 'auto_dispose.dart' as auto_dispose;
 import 'buffer_stream_callbacks.dart' as buffer_stream_callbacks;
-import 'hot_restart_lifecycle.dart' as hot_restart_lifecycle;
 import 'buffer_stream_extended.dart' as buffer_stream_extended;
 import 'buffer_stream_small_mp3.dart' as buffer_stream_small_mp3;
 import 'compressor_filter.dart' as compressor_filter;
@@ -12,6 +11,7 @@ import 'create_notes.dart' as create_notes;
 import 'equalizer_filter.dart' as equalizer_filter;
 import 'global_filters.dart' as global_filters;
 import 'handles.dart' as handles;
+import 'hot_restart_lifecycle.dart' as hot_restart_lifecycle;
 import 'limiter_filter.dart' as limiter_filter;
 import 'load_mem.dart' as load_mem;
 import 'looping.dart' as looping;
@@ -201,6 +201,8 @@ final List<TestEntry> allTests = [
   const TestEntry(
     name: 'BufferStreamCallbacks',
     run: buffer_stream_callbacks.testBufferStreamCallbacks,
+  ),
+  const TestEntry(
     name: 'HotRestartLifecycle',
     run: hot_restart_lifecycle.testHotRestartLifecycle,
   ),

--- a/example/tests/tests/buffer_stream_callbacks.dart
+++ b/example/tests/tests/buffer_stream_callbacks.dart
@@ -17,9 +17,9 @@ Uint8List _generatePcmData({
   for (var i = 0; i < sampleCount; i++) {
     final sample =
         (sin(2 * pi * frequency * i / sampleRate) * 16000).toInt().clamp(
-          -32768,
-          32767,
-        );
+              -32768,
+              32767,
+            );
     bytes.setInt16(i * 2, sample, Endian.little);
   }
   return bytes.buffer.asUint8List();

--- a/example/tests/tests/buffer_stream_callbacks.dart
+++ b/example/tests/tests/buffer_stream_callbacks.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_soloud/flutter_soloud.dart';
+
+import 'common.dart';
+
+/// Generate a short sine-wave PCM buffer (mono, s16le).
+Uint8List _generatePcmData({
+  int sampleRate = 24000,
+  double durationSeconds = 1.0,
+  double frequency = 440,
+}) {
+  final sampleCount = (sampleRate * durationSeconds).toInt();
+  final bytes = ByteData(sampleCount * 2); // 16-bit samples = 2 bytes each
+  for (var i = 0; i < sampleCount; i++) {
+    final sample =
+        (sin(2 * pi * frequency * i / sampleRate) * 16000).toInt().clamp(
+          -32768,
+          32767,
+        );
+    bytes.setInt16(i * 2, sample, Endian.little);
+  }
+  return bytes.buffer.asUint8List();
+}
+
+/// Test that buffer stream callbacks survive for the lifetime of the sound
+/// and are properly released on disposal.
+///
+/// PR #445 fixes a bug where NativeCallable wrappers for onBuffering /
+/// onMetadata were dropped immediately after setBufferStream(), letting the
+/// GC free the trampoline while native still held its address.
+Future<StringBuffer> testBufferStreamCallbacks() async {
+  final buf = StringBuffer();
+  await initialize();
+  final pcm = _generatePcmData();
+
+  // ── 1. onBuffering callback fires ───────────────────────────────────────
+  //    Play BEFORE adding data so the stream enters the buffering state,
+  //    then add data so it transitions to un-buffering — both fire the
+  //    onBuffering callback.
+  final bufferingEvents = <bool>[];
+  final unbufferingReceived = Completer<void>();
+
+  final stream1 = SoLoud.instance.setBufferStream(
+    bufferingTimeNeeds: 0.3,
+    onBuffering: (isBuffering, handle, time) {
+      bufferingEvents.add(isBuffering);
+      if (!isBuffering && !unbufferingReceived.isCompleted) {
+        unbufferingReceived.complete();
+      }
+    },
+  );
+
+  // Start playback with no data — enters buffering (paused) state.
+  SoLoud.instance.play(stream1);
+  await delay(100);
+
+  // Feed data — once enough accumulates the stream un-buffers.
+  SoLoud.instance.addAudioDataStream(stream1, pcm);
+
+  await unbufferingReceived.future.timeout(
+    const Duration(seconds: 5),
+    onTimeout: () {
+      assert(false, 'onBuffering callback never fired');
+    },
+  );
+
+  assert(bufferingEvents.isNotEmpty, 'should have received buffering events');
+  buf.writeln('1. onBuffering callback fired: OK '
+      '(${bufferingEvents.length} events)');
+
+  // ── 2. Dispose the sound — no crash ─────────────────────────────────────
+  await SoLoud.instance.disposeSource(stream1);
+  await delay(100);
+  buf.writeln('2. disposeSource after callbacks: OK');
+
+  // ── 3. New stream after disposal — callbacks still work ─────────────────
+  final secondUnbuffering = Completer<void>();
+
+  final stream2 = SoLoud.instance.setBufferStream(
+    bufferingTimeNeeds: 0.3,
+    onBuffering: (isBuffering, handle, time) {
+      if (!isBuffering && !secondUnbuffering.isCompleted) {
+        secondUnbuffering.complete();
+      }
+    },
+  );
+
+  SoLoud.instance.play(stream2);
+  await delay(100);
+  SoLoud.instance.addAudioDataStream(stream2, pcm);
+
+  await secondUnbuffering.future.timeout(
+    const Duration(seconds: 5),
+    onTimeout: () {
+      assert(false, 'second onBuffering callback never fired');
+    },
+  );
+  buf.writeln('3. New stream callbacks work after prior disposal: OK');
+
+  // ── 4. disposeAllSources cleans up everything ───────────────────────────
+  await SoLoud.instance.disposeAllSources();
+  await delay(100);
+  buf.writeln('4. disposeAllSources after callback streams: OK');
+
+  deinit();
+
+  debugPrint(buf.toString());
+  return buf;
+}

--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -60,10 +60,7 @@ typedef DartdartStateChangedCallbackTFunction =
 typedef OnMetadataCallbackTFunction = void Function(NativeAudioMetadata);
 
 final class _BufferStreamNativeCallbacks {
-  _BufferStreamNativeCallbacks({
-    this.onBuffering,
-    this.onMetadata,
-  });
+  _BufferStreamNativeCallbacks({this.onBuffering, this.onMetadata});
 
   final ffi.NativeCallable<ffi.Void Function(ffi.Bool, ffi.Int, ffi.Double)>?
   onBuffering;
@@ -105,8 +102,8 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
   ffi.NativeCallable<DartFileLoadedCallbackTFunction>? nativeFileLoadedCallable;
   ffi.NativeCallable<DartStateChangedCallbackTFunction>?
   nativeStateChangedCallable;
-  final Map<int, _BufferStreamNativeCallbacks>
-  _bufferStreamNativeCallables = {};
+  final Map<int, _BufferStreamNativeCallbacks> _bufferStreamNativeCallables =
+      {};
 
   void _disposeBufferStreamCallbacks(SoundHash soundHash) {
     _bufferStreamNativeCallables.remove(soundHash.hash)?.close();

--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -59,6 +59,24 @@ typedef DartdartStateChangedCallbackTFunction =
 
 typedef OnMetadataCallbackTFunction = void Function(NativeAudioMetadata);
 
+final class _BufferStreamNativeCallbacks {
+  _BufferStreamNativeCallbacks({
+    this.onBuffering,
+    this.onMetadata,
+  });
+
+  final ffi.NativeCallable<ffi.Void Function(ffi.Bool, ffi.Int, ffi.Double)>?
+  onBuffering;
+  final ffi.NativeCallable<ffi.Void Function(NativeAudioMetadata)>? onMetadata;
+
+  bool get hasCallbacks => onBuffering != null || onMetadata != null;
+
+  void close() {
+    onBuffering?.close();
+    onMetadata?.close();
+  }
+}
+
 /// FFI bindings to SoLoud
 @internal
 class FlutterSoLoudFfi extends FlutterSoLoud {
@@ -87,6 +105,19 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
   ffi.NativeCallable<DartFileLoadedCallbackTFunction>? nativeFileLoadedCallable;
   ffi.NativeCallable<DartStateChangedCallbackTFunction>?
   nativeStateChangedCallable;
+  final Map<int, _BufferStreamNativeCallbacks>
+  _bufferStreamNativeCallables = {};
+
+  void _disposeBufferStreamCallbacks(SoundHash soundHash) {
+    _bufferStreamNativeCallables.remove(soundHash.hash)?.close();
+  }
+
+  void _disposeAllBufferStreamCallbacks() {
+    for (final callbacks in _bufferStreamNativeCallables.values) {
+      callbacks.close();
+    }
+    _bufferStreamNativeCallables.clear();
+  }
 
   void _voiceEndedCallback(ffi.Pointer<ffi.UnsignedInt> handle) {
     _log.finest(() => 'VOICE ENDED EVENT handle: ${handle.value}');
@@ -137,6 +168,7 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
 
   @override
   void disposeNativeCallables() {
+    _disposeAllBufferStreamCallbacks();
     nativeVoiceEndedCallable?.close();
     nativeFileLoadedCallable?.close();
     nativeStateChangedCallable?.close();
@@ -453,25 +485,18 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
     OnBufferingCallbackTFunction? onBuffering,
     OnMetadataCallbackTFunction? onMetadata,
   ) {
-    // Create a NativeCallable for the given [onBuffering] callback.
-    ffi.NativeCallable<ffi.Void Function(ffi.Bool, ffi.Int, ffi.Double)>?
-    nativeOnBufferingCallable;
-    if (onBuffering != null) {
-      nativeOnBufferingCallable =
-          ffi.NativeCallable<
-            ffi.Void Function(ffi.Bool, ffi.Int, ffi.Double)
-          >.listener(onBuffering);
-    }
-
-    // Create a NativeCallable for the given [onMetadata] callback.
-    ffi.NativeCallable<ffi.Void Function(NativeAudioMetadata)>?
-    nativeOnMetadataCallable;
-    if (onMetadata != null) {
-      nativeOnMetadataCallable =
-          ffi.NativeCallable<ffi.Void Function(NativeAudioMetadata)>.listener(
-            onMetadata,
-          );
-    }
+    final nativeCallbacks = _BufferStreamNativeCallbacks(
+      onBuffering: onBuffering == null
+          ? null
+          : ffi.NativeCallable<
+              ffi.Void Function(ffi.Bool, ffi.Int, ffi.Double)
+            >.listener(onBuffering),
+      onMetadata: onMetadata == null
+          ? null
+          : ffi.NativeCallable<ffi.Void Function(NativeAudioMetadata)>.listener(
+              onMetadata,
+            ),
+    );
 
     final ffi.Pointer<ffi.UnsignedInt> hash = calloc(
       ffi.sizeOf<ffi.UnsignedInt>(),
@@ -484,11 +509,16 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
       sampleRate,
       channels,
       format,
-      nativeOnBufferingCallable?.nativeFunction ?? ffi.nullptr,
-      nativeOnMetadataCallable?.nativeFunction ?? ffi.nullptr,
+      nativeCallbacks.onBuffering?.nativeFunction ?? ffi.nullptr,
+      nativeCallbacks.onMetadata?.nativeFunction ?? ffi.nullptr,
     );
     final soundHash = SoundHash(hash.value);
     final ret = (error: PlayerErrors.values[e], soundHash: soundHash);
+    if (ret.error == PlayerErrors.noError && nativeCallbacks.hasCallbacks) {
+      _bufferStreamNativeCallables[soundHash.hash] = nativeCallbacks;
+    } else {
+      nativeCallbacks.close();
+    }
     calloc.free(hash);
     return ret;
   }
@@ -904,7 +934,8 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
 
   @override
   void disposeSound(SoundHash soundHash) {
-    return _disposeSound(soundHash.hash);
+    _disposeSound(soundHash.hash);
+    _disposeBufferStreamCallbacks(soundHash);
   }
 
   late final _disposeSoundPtr =
@@ -915,7 +946,8 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
 
   @override
   void disposeAllSound() {
-    return _disposeAllSound();
+    _disposeAllSound();
+    _disposeAllBufferStreamCallbacks();
   }
 
   late final _disposeAllSoundPtr =


### PR DESCRIPTION
## Description

Fixes a Dart FFI callback lifetime bug in `setBufferStream()`.

The `NativeCallable` wrappers created for `onBuffering` and `onMetadata` callbacks were dropped immediately after `setBufferStream()` returned. With no Dart-side reference keeping them alive, the GC could free the trampoline while native code still held the function pointer — leading to a crash on the next buffering state change or metadata event.

### What changed

- **Callback retention**: Per-stream `NativeCallable` wrappers are now stored in a `Map<int, _BufferStreamNativeCallbacks>` keyed by sound hash, keeping them alive for the lifetime of the stream.
- **Cleanup on dispose**: `disposeSound()` cleans up the single stream's callbacks; `disposeAllSound()` cleans up all of them.
- **Cleanup on deinit**: `disposeNativeCallables()` (called during `deinit()` / hot-restart recovery) now also clears the callback map, preventing leaks across engine restarts.
- **Removed redundant dispose**: The old code called `_disposeBufferStreamCallbacks()` before inserting a new entry — this closed the previous callbacks before the map entry was replaced, which was unnecessary since map insertion handles replacement.

### Test

Added `BufferStreamCallbacks` on-device integration test (`example/tests/tests/`) that:
1. Creates a buffer stream with `onBuffering` callback
2. Plays before adding data to trigger the buffering → unbuffering transition
3. Verifies the callback fires
4. Disposes the stream (no crash)
5. Creates a second stream — verifies callbacks still work after prior disposal
6. Calls `disposeAllSources` — verifies bulk cleanup

**Note:** This PR should be merged after or together with #444 (hot-restart callback rebind), since `disposeNativeCallables` cleanup depends on the callback registration lifecycle introduced there.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)