### PR TITLE
fix: SoLoudTemporaryFolderFailedException still possible in 4.0.2 when isInitialized=true but loader temp dir is null

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -39,7 +39,7 @@ SPEC CHECKSUMS:
   audio_service: aa99a6ba2ae7565996015322b0bb024e1d25c6fd
   audio_session: eaca2512cf2b39212d724f35d11f46180ad3a33e
   file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
-  flutter_soloud: 7320627f3d1e7967f6ba1c46068937b939b9e750
+  flutter_soloud: b7285a18f8258184a4836662158c3209567e676e
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -197,7 +197,9 @@ interface class SoLoud {
   /// Use [isInitialized] only if you want to check the current status of
   /// the engine synchronously and you don't care that it might be ready soon.
   bool get isInitialized =>
-      _nativeCallbacksInitialized && _controller.soLoudFFI.isInited();
+      _nativeCallbacksInitialized &&
+      _controller.soLoudFFI.isInited() &&
+      _loader.isInitialized;
 
   /// Backing of [activeSounds].
   final List<AudioSource> _activeSounds = [];

--- a/lib/src/utils/loader_base.dart
+++ b/lib/src/utils/loader_base.dart
@@ -10,6 +10,9 @@ interface class SoLoudLoader {
   /// To reflect [SoLoudLoader] for `io`.
   bool automaticCleanup = false;
 
+  /// Whether the loader has been initialized.
+  bool get isInitialized => false;
+
   Future<void> initialize() async =>
       throw UnsupportedError('platform not supported');
 

--- a/lib/src/utils/loader_io.dart
+++ b/lib/src/utils/loader_io.dart
@@ -27,6 +27,11 @@ class SoLoudLoader {
   /// deleting files in the temporary directory at various points.
   bool automaticCleanup = false;
 
+  bool _isInitialized = false;
+
+  /// Whether the loader has been initialized.
+  bool get isInitialized => _isInitialized;
+
   final Map<_TemporaryFileIdentifier, File> _temporaryFiles = {};
 
   Directory? _temporaryDirectory;
@@ -134,6 +139,7 @@ class SoLoudLoader {
     }
 
     _temporaryDirectory = directory;
+    _isInitialized = true;
     _log.info('Temporary directory initialized at ${directory.path}');
 
     if (automaticCleanup) {

--- a/lib/src/utils/loader_web.dart
+++ b/lib/src/utils/loader_web.dart
@@ -20,8 +20,15 @@ class SoLoudLoader {
   /// To reflect [SoLoudLoader] for `io`.
   bool automaticCleanup = false;
 
+  bool _isInitialized = false;
+
+  /// Whether the loader has been initialized.
+  bool get isInitialized => _isInitialized;
+
   /// To reflect [SoLoudLoader] for `io`.
-  Future<void> initialize() async {}
+  Future<void> initialize() async {
+    _isInitialized = true;
+  }
 
   /// Loads the asset with [key] (e.g. `assets/sound.mp3`), and return
   /// the file byte as `Uint8List` to be passed to `SoLoud.LoadMem` for


### PR DESCRIPTION
## Description

Make `SoLoud.isInitialized` reflect both engine state AND loader state.

To the class `SoLoudLoader` has been added the `isInitialized` getter to be checked in `SoLoud.isInitialized`.

fixes #447

## Type of Change

- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
