### PR TITLE
commented out the asserts in the `init` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-#### 4.0.3 (XX Xxx 2026)
+#### 4.0.3 (24 Apr 2026)
 - fix: rebind Dart callbacks after hot restart #444. Thanks to @skylartaylor
 - fix: retain BufferStream callbacks until disposal #445. Thanks to @skylartaylor
+- fix: removed the asserts in the init method #453
 - web fix: small sound bleed after stop and play #446
-- web fix: new way to load audio assets (loadAssets and loadMem) on web to solve UI freeze when loading
+- web fix: new way to load audio from memory (loadAssets and loadMem) on web to solve UI freeze when loading
 
 #### 4.0.2 (10 Apr 2026)
 - apple: fix building issue with XCode

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -348,22 +348,24 @@ interface class SoLoud {
     final nativeIsInitialized = _controller.soLoudFFI.isInited();
     _log.finest('init() called');
 
+    // Removing these asserts because they could not be true after a
+    // hot restart or after calling deinit(). Discussed in #452.
     // Making extra sure no state is dangling after a hot-restart.
-    assert(
-      voiceEndedCompleters.isEmpty,
-      'voiceEndedCompleters is not empty. '
-      'Probably the developer forgot to call deinit().',
-    );
-    assert(
-      loadedFileCompleters.isEmpty,
-      'loadedFileCompleters is not empty. '
-      'Probably the developer forgot to call deinit().',
-    );
-    assert(
-      _activeSounds.isEmpty,
-      '_activeSounds is not empty. '
-      'Probably the developer forgot to call deinit().',
-    );
+    // assert(
+    //   voiceEndedCompleters.isEmpty,
+    //   'voiceEndedCompleters is not empty. '
+    //   'Probably the developer forgot to call deinit().',
+    // );
+    // assert(
+    //   loadedFileCompleters.isEmpty,
+    //   'loadedFileCompleters is not empty. '
+    //   'Probably the developer forgot to call deinit().',
+    // );
+    // assert(
+    //   _activeSounds.isEmpty,
+    //   '_activeSounds is not empty. '
+    //   'Probably the developer forgot to call deinit().',
+    // );
     voiceEndedCompleters.clear();
     loadedFileCompleters.clear();
     _activeSounds.clear();


### PR DESCRIPTION
## Description

It seems that in some cases the asserts in the `init` could not be true after a hot restart or after calling `deinit`. 

Closes #452.


## Type of Change

- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
