### PR TITLE
Fix iOS SPM duplicate miniaudio symbols

### DIFF
--- a/ios/flutter_soloud/Sources/flutter_soloud/flutter_soloud.mm
+++ b/ios/flutter_soloud/Sources/flutter_soloud/flutter_soloud.mm
@@ -1,3 +1,5 @@
 // Relative import to be able to reuse the C sources.
 // See the comment in the podspec for more information.
+#define MA_API static
+#include "miniaudio_objc_prefix.h"
 #include "../../../../src/flutter_soloud.cpp"


### PR DESCRIPTION
## Summary

Fixes iOS SPM linking failures when another native dependency also embeds miniaudio, for example `rive_native`.

`flutter_soloud` currently includes the aggregated native source from `flutter_soloud.mm`, which pulls in miniaudio with default `MA_API extern` visibility. That exports many `ma_*` symbols from the `flutter_soloud` object. If another Swift Package dependency also compiles miniaudio, the iOS linker fails with duplicate symbols.

This change:

- defines `MA_API static` before including the aggregated source, keeping miniaudio API symbols private to the translation unit;
- includes the existing `miniaudio_objc_prefix.h` before miniaudio is included, so the existing Objective-C class rename is applied in the SPM path.

## Example failure

In a Flutter iOS app using both `flutter_soloud` via SPM and `rive` / `rive_native`, the simulator build can fail with duplicate symbols from:

- `flutter_soloud.o`
- `libRiveNative.a(.../miniaudio.o)`

Typical duplicate symbols include `ma_mutex_lock`, `ma_node_get_state_time`, `ma_sound_get_velocity`, `ma_volume_db_to_linear`, and `OBJC_METACLASS_$_ma_ios_notification_handler`.

## Validation

Validated in a Flutter app that previously failed with `ld: 1012 duplicate symbols`; after applying this patch the iOS simulator build and launch succeeded.
