### PR TITLE
feat(audio): expose master output capture

### DIFF
--- a/lib/src/bindings/bindings_player.dart
+++ b/lib/src/bindings/bindings_player.dart
@@ -985,6 +985,35 @@ abstract class FlutterSoLoud {
     bool average = false,
   });
 
+  // ///////////////////////////////////////
+  // output capture
+  // ///////////////////////////////////////
+
+  /// Enables or disables capture of the final mixed output.
+  ///
+  /// Captured samples are interleaved float32 PCM in the engine output format.
+  @mustBeOverridden
+  PlayerErrors setOutputCaptureEnabled(
+    bool enabled, {
+    int maxBufferedFrames = 44100,
+  });
+
+  /// Reads up to [maxFrames] captured frames.
+  ///
+  /// The returned list contains interleaved float32 samples. Its length is
+  /// `framesRead * channels`, where `channels` comes from
+  /// [getOutputCaptureFormat].
+  @mustBeOverridden
+  Float32List readOutputCapture(int maxFrames);
+
+  /// Returns captured frames currently available to read.
+  @mustBeOverridden
+  int getOutputCaptureAvailableFrames();
+
+  /// Returns the capture sample rate and channel count.
+  @mustBeOverridden
+  ({PlayerErrors error, int sampleRate, int channels}) getOutputCaptureFormat();
+
   /////////////////////////////////////////
   /// Mixing Bus
   /// https://solhsa.com/soloud/mixbus.html

--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -2388,6 +2388,113 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
         )
       >();
 
+  // ///////////////////////////////////////
+  // output capture
+  // ///////////////////////////////////////
+
+  @override
+  PlayerErrors setOutputCaptureEnabled(
+    bool enabled, {
+    int maxBufferedFrames = 44100,
+  }) {
+    final error = _setOutputCaptureEnabled(enabled, maxBufferedFrames);
+    return PlayerErrors.values[error];
+  }
+
+  late final _setOutputCaptureEnabledPtr =
+      _lookup<
+        ffi.NativeFunction<ffi.UnsignedInt Function(ffi.Bool, ffi.UnsignedInt)>
+      >('setOutputCaptureEnabled');
+  late final _setOutputCaptureEnabled = _setOutputCaptureEnabledPtr
+      .asFunction<int Function(bool, int)>();
+
+  @override
+  Float32List readOutputCapture(int maxFrames) {
+    final format = getOutputCaptureFormat();
+    if (format.error != PlayerErrors.noError ||
+        format.channels <= 0 ||
+        maxFrames <= 0) {
+      return Float32List(0);
+    }
+
+    final out = calloc<ffi.Float>(maxFrames * format.channels);
+    final framesRead = calloc<ffi.UnsignedInt>();
+    try {
+      final error = _readOutputCapture(out, maxFrames, framesRead);
+      if (PlayerErrors.values[error] != PlayerErrors.noError ||
+          framesRead.value == 0) {
+        return Float32List(0);
+      }
+
+      final sampleCount = framesRead.value * format.channels;
+      return Float32List.fromList(out.asTypedList(sampleCount));
+    } finally {
+      calloc
+        ..free(out)
+        ..free(framesRead);
+    }
+  }
+
+  late final _readOutputCapturePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.UnsignedInt Function(
+            ffi.Pointer<ffi.Float>,
+            ffi.UnsignedInt,
+            ffi.Pointer<ffi.UnsignedInt>,
+          )
+        >
+      >('readOutputCapture');
+  late final _readOutputCapture = _readOutputCapturePtr
+      .asFunction<
+        int Function(ffi.Pointer<ffi.Float>, int, ffi.Pointer<ffi.UnsignedInt>)
+      >();
+
+  @override
+  int getOutputCaptureAvailableFrames() {
+    return _getOutputCaptureAvailableFrames();
+  }
+
+  late final _getOutputCaptureAvailableFramesPtr =
+      _lookup<ffi.NativeFunction<ffi.UnsignedInt Function()>>(
+        'getOutputCaptureAvailableFrames',
+      );
+  late final _getOutputCaptureAvailableFrames =
+      _getOutputCaptureAvailableFramesPtr.asFunction<int Function()>();
+
+  @override
+  ({PlayerErrors error, int sampleRate, int channels})
+  getOutputCaptureFormat() {
+    final sampleRate = calloc<ffi.UnsignedInt>();
+    final channels = calloc<ffi.UnsignedInt>();
+    try {
+      final error = _getOutputCaptureFormat(sampleRate, channels);
+      return (
+        error: PlayerErrors.values[error],
+        sampleRate: sampleRate.value,
+        channels: channels.value,
+      );
+    } finally {
+      calloc
+        ..free(sampleRate)
+        ..free(channels);
+    }
+  }
+
+  late final _getOutputCaptureFormatPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.UnsignedInt Function(
+            ffi.Pointer<ffi.UnsignedInt>,
+            ffi.Pointer<ffi.UnsignedInt>,
+          )
+        >
+      >('getOutputCaptureFormat');
+  late final _getOutputCaptureFormat = _getOutputCaptureFormatPtr
+      .asFunction<
+        int Function(ffi.Pointer<ffi.UnsignedInt>, ffi.Pointer<ffi.UnsignedInt>)
+      >();
+
   /////////////////////////////////////////
   /// Mixing Bus
   /// https://solhsa.com/soloud/mixbus.html

--- a/lib/src/bindings/bindings_player_web.dart
+++ b/lib/src/bindings/bindings_player_web.dart
@@ -1207,6 +1207,34 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     return samples;
   }
 
+  // ///////////////////////////////////////
+  // output capture
+  // ///////////////////////////////////////
+
+  @override
+  PlayerErrors setOutputCaptureEnabled(
+    bool enabled, {
+    int maxBufferedFrames = 44100,
+  }) {
+    return PlayerErrors.notImplemented;
+  }
+
+  @override
+  Float32List readOutputCapture(int maxFrames) {
+    return Float32List(0);
+  }
+
+  @override
+  int getOutputCaptureAvailableFrames() {
+    return 0;
+  }
+
+  @override
+  ({PlayerErrors error, int sampleRate, int channels})
+  getOutputCaptureFormat() {
+    return (error: PlayerErrors.notImplemented, sampleRate: 0, channels: 0);
+  }
+
   /////////////////////////////////////////
   /// Mixing Bus
   /// https://solhsa.com/soloud/mixbus.html

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -293,6 +293,9 @@ interface class SoLoud {
   /// The channels the engine was initialized with.
   Channels _channels = Channels.stereo;
 
+  StreamController<Float32List>? _outputCaptureController;
+  Timer? _outputCaptureTimer;
+
   /// Initializes the audio engine.
   ///
   /// Run this before anything else, and `await` its result in a try/catch.
@@ -455,6 +458,7 @@ interface class SoLoud {
   /// or inside "AppLifecycleListener.onExitRequested".
   void deinit() {
     _log.finest('deinit() called');
+    _stopOutputCaptureStream();
     _nativeCallbacksInitialized = false;
     _controller.soLoudFFI.disposeNativeCallables();
     _controller.soLoudFFI.disposeAllSound();
@@ -3071,6 +3075,165 @@ interface class SoLoud {
     });
 
     return samples;
+  }
+
+  /// Creates a stream of captured master output with its audio format.
+  ///
+  /// This is the simplest API for output capture. Listen to the returned
+  /// [stream] to enable native capture; cancel the subscription to disable it.
+  ///
+  /// [maxBufferedFrames] controls the native ring buffer size.
+  /// [chunkFrames] controls the maximum frames emitted in a single stream
+  /// event.
+  /// [interval] controls how often Dart drains the native capture buffer.
+  ({int sampleRate, int channels, Stream<Float32List> stream}) outputCapture({
+    int maxBufferedFrames = 44100,
+    int chunkFrames = 2048,
+    Duration interval = const Duration(milliseconds: 20),
+  }) {
+    if (!isInitialized) {
+      throw const SoLoudNotInitializedException();
+    }
+    final format = _getOutputCaptureFormat();
+    return (
+      sampleRate: format.sampleRate,
+      channels: format.channels,
+      stream: _outputCaptureStream(
+        maxBufferedFrames: maxBufferedFrames,
+        chunkFrames: chunkFrames,
+        interval: interval,
+      ),
+    );
+  }
+
+  Stream<Float32List> _outputCaptureStream({
+    int maxBufferedFrames = 44100,
+    int chunkFrames = 2048,
+    Duration interval = const Duration(milliseconds: 20),
+  }) {
+    if (!isInitialized) {
+      throw const SoLoudNotInitializedException();
+    }
+    if (maxBufferedFrames <= 0) {
+      throw ArgumentError.value(
+        maxBufferedFrames,
+        'maxBufferedFrames',
+        'Must be greater than zero.',
+      );
+    }
+    if (chunkFrames <= 0) {
+      throw ArgumentError.value(
+        chunkFrames,
+        'chunkFrames',
+        'Must be greater than zero.',
+      );
+    }
+
+    late final StreamController<Float32List> controller;
+
+    void drainCapture() {
+      if (!isInitialized || controller.isClosed) {
+        _stopOutputCaptureStream();
+        return;
+      }
+
+      try {
+        final availableFrames = _getOutputCaptureAvailableFrames();
+        if (availableFrames <= 0 || controller.isClosed) {
+          return;
+        }
+
+        final framesToRead = availableFrames < chunkFrames
+            ? availableFrames
+            : chunkFrames;
+        final samples = _readOutputCapture(framesToRead);
+        if (samples.isNotEmpty) {
+          controller.add(samples);
+        }
+      } catch (error, stackTrace) {
+        controller.addError(error, stackTrace);
+        _stopOutputCaptureStream();
+      }
+    }
+
+    controller = StreamController<Float32List>(
+      onListen: () {
+        if (_outputCaptureController != null) {
+          controller.addError(
+            StateError('An output capture stream is already active.'),
+          );
+          unawaited(controller.close());
+          return;
+        }
+
+        _outputCaptureController = controller;
+        try {
+          _setOutputCaptureEnabled(
+            true,
+            maxBufferedFrames: maxBufferedFrames,
+          );
+        } catch (error, stackTrace) {
+          controller.addError(error, stackTrace);
+          _stopOutputCaptureStream();
+          return;
+        }
+        _outputCaptureTimer = Timer.periodic(interval, (_) => drainCapture());
+      },
+      onCancel: () {
+        if (_outputCaptureController == controller) {
+          _stopOutputCaptureStream(closeController: false);
+        }
+      },
+    );
+    return controller.stream;
+  }
+
+  void _setOutputCaptureEnabled(
+    bool enabled, {
+    int maxBufferedFrames = 44100,
+  }) {
+    final error = _controller.soLoudFFI.setOutputCaptureEnabled(
+      enabled,
+      maxBufferedFrames: maxBufferedFrames,
+    );
+    if (error != PlayerErrors.noError) {
+      throw SoLoudCppException.fromPlayerError(error);
+    }
+  }
+
+  Float32List _readOutputCapture(int maxFrames) {
+    return _controller.soLoudFFI.readOutputCapture(maxFrames);
+  }
+
+  int _getOutputCaptureAvailableFrames() {
+    return _controller.soLoudFFI.getOutputCaptureAvailableFrames();
+  }
+
+  ({int sampleRate, int channels}) _getOutputCaptureFormat() {
+    final format = _controller.soLoudFFI.getOutputCaptureFormat();
+    if (format.error != PlayerErrors.noError) {
+      throw SoLoudCppException.fromPlayerError(format.error);
+    }
+    return (sampleRate: format.sampleRate, channels: format.channels);
+  }
+
+  void _stopOutputCaptureStream({bool closeController = true}) {
+    _outputCaptureTimer?.cancel();
+    _outputCaptureTimer = null;
+
+    if (_controller.soLoudFFI.isInited()) {
+      final error = _controller.soLoudFFI.setOutputCaptureEnabled(false);
+      if (error != PlayerErrors.noError &&
+          error != PlayerErrors.notImplemented) {
+        _logPlayerError(error, from: 'setOutputCaptureEnabled(false)');
+      }
+    }
+
+    final controller = _outputCaptureController;
+    _outputCaptureController = null;
+    if (closeController && controller != null && !controller.isClosed) {
+      unawaited(controller.close());
+    }
   }
 
   /////////////////////////////////////////

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1855,6 +1855,38 @@ readSamplesFromMem(const unsigned char *buffer, unsigned long dataSize,
 }
 
 /////////////////////////////////////////
+/// Output capture
+/////////////////////////////////////////
+
+FFI_PLUGIN_EXPORT enum PlayerErrors
+setOutputCaptureEnabled(bool enabled, unsigned int maxBufferedFrames) {
+  if (player.get() == nullptr || !player.get()->isInited())
+    return backendNotInited;
+  return player.get()->setOutputCaptureEnabled(enabled, maxBufferedFrames);
+}
+
+FFI_PLUGIN_EXPORT enum PlayerErrors
+readOutputCapture(float *out, unsigned int maxFrames,
+                  unsigned int *framesRead) {
+  if (player.get() == nullptr || !player.get()->isInited())
+    return backendNotInited;
+  return player.get()->readOutputCapture(out, maxFrames, framesRead);
+}
+
+FFI_PLUGIN_EXPORT unsigned int getOutputCaptureAvailableFrames() {
+  if (player.get() == nullptr || !player.get()->isInited())
+    return 0;
+  return player.get()->getOutputCaptureAvailableFrames();
+}
+
+FFI_PLUGIN_EXPORT enum PlayerErrors
+getOutputCaptureFormat(unsigned int *sampleRate, unsigned int *channels) {
+  if (player.get() == nullptr || !player.get()->isInited())
+    return backendNotInited;
+  return player.get()->getOutputCaptureFormat(sampleRate, channels);
+}
+
+/////////////////////////////////////////
 /// Mixing Bus
 /// https://solhsa.com/soloud/mixbus.html
 /// https://solhsa.com/soloud/soloud_20200207.html#mixing-bus

--- a/src/output_capture.h
+++ b/src/output_capture.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#ifndef OUTPUT_CAPTURE_H
+#define OUTPUT_CAPTURE_H
+
+#include <atomic>
+#include <cstddef>
+#include <cstring>
+#include <vector>
+
+class OutputCaptureBuffer {
+public:
+  OutputCaptureBuffer() = default;
+
+  bool init(size_t capacityFrames, size_t channels) {
+    if (capacityFrames == 0 || channels == 0) {
+      return false;
+    }
+
+    size_t capacity = 1;
+    while (capacity < capacityFrames) {
+      capacity <<= 1;
+    }
+
+    mChannels = channels;
+    mBuffer.assign(capacity * channels, 0.0f);
+    mMask = capacity - 1;
+    clear();
+    return true;
+  }
+
+  void clear() {
+    mHead.store(0, std::memory_order_relaxed);
+    mTail.store(0, std::memory_order_relaxed);
+  }
+
+  size_t available() const {
+    const size_t head = mHead.load(std::memory_order_acquire);
+    const size_t tail = mTail.load(std::memory_order_acquire);
+    return head - tail;
+  }
+
+  void push(const float *data, size_t frames, size_t channels) {
+    if (mChannels != channels || mChannels == 0 || data == nullptr ||
+        frames == 0) {
+      return;
+    }
+
+    const size_t capacityFrames = mBuffer.size() / mChannels;
+    if (capacityFrames == 0) {
+      return;
+    }
+
+    if (frames > capacityFrames) {
+      const size_t skipped = frames - capacityFrames;
+      data += skipped * mChannels;
+      frames = capacityFrames;
+    }
+
+    const size_t head = mHead.load(std::memory_order_relaxed);
+    size_t tail = mTail.load(std::memory_order_acquire);
+    const size_t used = head - tail;
+    const size_t free = capacityFrames - used;
+    if (frames > free) {
+      const size_t skipped = frames - free;
+      data += skipped * mChannels;
+      frames = free;
+      if (frames == 0) {
+        return;
+      }
+    }
+
+    const size_t startFrame = head & mMask;
+    const size_t start = startFrame * mChannels;
+    const size_t firstFrames =
+        frames < capacityFrames - startFrame
+            ? frames
+            : capacityFrames - startFrame;
+    std::memcpy(&mBuffer[start], data,
+                firstFrames * mChannels * sizeof(float));
+    if (frames > firstFrames) {
+      std::memcpy(&mBuffer[0], data + firstFrames * mChannels,
+                  (frames - firstFrames) * mChannels * sizeof(float));
+    }
+
+    mHead.store(head + frames, std::memory_order_release);
+  }
+
+  size_t pop(float *out, size_t frames, size_t channels) {
+    if (mChannels != channels || out == nullptr || frames == 0) {
+      return 0;
+    }
+
+    size_t tail = mTail.load(std::memory_order_relaxed);
+    const size_t head = mHead.load(std::memory_order_acquire);
+    const size_t availableFrames = head - tail;
+    const size_t toRead = frames < availableFrames ? frames : availableFrames;
+    if (toRead == 0) {
+      return 0;
+    }
+
+    const size_t capacityFrames = mBuffer.size() / mChannels;
+    const size_t startFrame = tail & mMask;
+    const size_t start = startFrame * mChannels;
+    const size_t first = toRead < capacityFrames - startFrame
+                             ? toRead
+                             : capacityFrames - startFrame;
+    std::memcpy(out, &mBuffer[start], first * mChannels * sizeof(float));
+    if (toRead > first) {
+      std::memcpy(out + first * mChannels, &mBuffer[0],
+                  (toRead - first) * mChannels * sizeof(float));
+    }
+
+    mTail.store(tail + toRead, std::memory_order_release);
+    return toRead;
+  }
+
+private:
+  std::vector<float> mBuffer;
+  size_t mChannels = 0;
+  size_t mMask = 0;
+  std::atomic<size_t> mHead{0};
+  std::atomic<size_t> mTail{0};
+};
+
+#endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -25,6 +25,12 @@
 #define __WEB__ 0
 #endif
 
+namespace SoLoud
+{
+    typedef void (*miniaudio_output_capture_callback_t)(const float *samples, unsigned int frames, unsigned int channels, void *userData);
+    void miniaudio_set_output_capture_callback(miniaudio_output_capture_callback_t callback, void *userData);
+}
+
 Player::Player() : mInited(false), mFilters(&soloud, nullptr, nullptr) {}
 
 Player::~Player() {
@@ -55,6 +61,7 @@ void Player::dispose() {
     if (!mInited)
         return;
 
+    setOutputCaptureEnabled(false, 0);
     mInited = false;
 
     // Clean up SoLoud
@@ -1370,6 +1377,116 @@ PlayerErrors Player::play3d(
     }
     handle = newHandle;
     return PlayerErrors::noError;
+}
+
+/////////////////////////////////////////
+/// Output capture
+/////////////////////////////////////////
+
+PlayerErrors Player::setOutputCaptureEnabled(bool enabled,
+                                             unsigned int maxBufferedFrames)
+{
+    if (!mInited)
+        return backendNotInited;
+
+    if (!enabled)
+    {
+        mOutputCaptureEnabled.store(false, std::memory_order_release);
+        SoLoud::miniaudio_set_output_capture_callback(nullptr, nullptr);
+        std::atomic_store_explicit(
+            &mOutputCaptureBuffer,
+            std::shared_ptr<OutputCaptureBuffer>(),
+            std::memory_order_release);
+        return noError;
+    }
+
+    if (maxBufferedFrames == 0)
+        return invalidParameter;
+
+    auto buffer = std::make_shared<OutputCaptureBuffer>();
+    if (!buffer->init(static_cast<size_t>(maxBufferedFrames),
+                      static_cast<size_t>(mChannels)))
+        return outOfMemory;
+
+    std::atomic_store_explicit(
+        &mOutputCaptureBuffer,
+        buffer,
+        std::memory_order_release);
+    mOutputCaptureEnabled.store(true, std::memory_order_release);
+    SoLoud::miniaudio_set_output_capture_callback(
+        &Player::outputCaptureCallback, this);
+    return noError;
+}
+
+PlayerErrors Player::readOutputCapture(float *out, unsigned int maxFrames,
+                                       unsigned int *framesRead)
+{
+    if (!mInited)
+        return backendNotInited;
+    if (out == nullptr || framesRead == nullptr)
+        return invalidParameter;
+
+    *framesRead = 0;
+    auto buffer = std::atomic_load_explicit(
+        &mOutputCaptureBuffer,
+        std::memory_order_acquire);
+
+    if (!mOutputCaptureEnabled.load(std::memory_order_acquire) || !buffer)
+        return noError;
+
+    const size_t read = buffer->pop(out, static_cast<size_t>(maxFrames),
+                                    static_cast<size_t>(mChannels));
+    *framesRead = static_cast<unsigned int>(read);
+    return noError;
+}
+
+unsigned int Player::getOutputCaptureAvailableFrames()
+{
+    auto buffer = std::atomic_load_explicit(
+        &mOutputCaptureBuffer,
+        std::memory_order_acquire);
+
+    if (!mOutputCaptureEnabled.load(std::memory_order_acquire) || !buffer)
+        return 0;
+
+    return static_cast<unsigned int>(buffer->available());
+}
+
+PlayerErrors Player::getOutputCaptureFormat(unsigned int *sampleRate,
+                                            unsigned int *channels)
+{
+    if (!mInited)
+        return backendNotInited;
+    if (sampleRate == nullptr || channels == nullptr)
+        return invalidParameter;
+
+    *sampleRate = mSampleRate;
+    *channels = mChannels;
+    return noError;
+}
+
+void Player::outputCaptureCallback(const float *samples, unsigned int frames,
+                                   unsigned int channels, void *userData)
+{
+    if (userData == nullptr)
+        return;
+
+    static_cast<Player *>(userData)->writeOutputCapture(samples, frames, channels);
+}
+
+void Player::writeOutputCapture(const float *samples, unsigned int frames,
+                                unsigned int channels)
+{
+    auto buffer = std::atomic_load_explicit(
+        &mOutputCaptureBuffer,
+        std::memory_order_acquire);
+
+    if (!mOutputCaptureEnabled.load(std::memory_order_acquire) || !buffer ||
+        channels != mChannels)
+        return;
+
+    buffer->push(samples, static_cast<size_t>(frames),
+                 static_cast<size_t>(channels));
 }
 
 void Player::set3dSoundSpeed(float speed)

--- a/src/player.h
+++ b/src/player.h
@@ -9,6 +9,7 @@
 #include "audiobuffer/metadata_ffi.h"
 #include "enums.h"
 #include "filters/filters.h"
+#include "output_capture.h"
 #include "soloud/include/soloud.h"
 #include "soloud/include/soloud_speech.h"
 #include "soloud/src/backend/miniaudio/miniaudio.h"
@@ -593,6 +594,17 @@ public:
   void set3dSourceDopplerFactor(unsigned int handle, float dopplerFactor);
 
   /////////////////////////////////////////
+  /// Output capture
+  /////////////////////////////////////////
+  PlayerErrors setOutputCaptureEnabled(bool enabled,
+                                       unsigned int maxBufferedFrames);
+  PlayerErrors readOutputCapture(float *out, unsigned int maxFrames,
+                                 unsigned int *framesRead);
+  unsigned int getOutputCaptureAvailableFrames();
+  PlayerErrors getOutputCaptureFormat(unsigned int *sampleRate,
+                                      unsigned int *channels);
+
+  /////////////////////////////////////////
   /// Mixing Bus
   /// https://solhsa.com/soloud/mixbus.html
   /// https://solhsa.com/soloud/soloud_20200207.html#mixing-bus
@@ -638,6 +650,14 @@ private:
 
   std::map<unsigned int, BusData> busMap;
   unsigned int busIdCounter = 0;
+
+  std::shared_ptr<OutputCaptureBuffer> mOutputCaptureBuffer;
+  std::atomic<bool> mOutputCaptureEnabled{false};
+
+  static void outputCaptureCallback(const float *samples, unsigned int frames,
+                                    unsigned int channels, void *userData);
+  void writeOutputCapture(const float *samples, unsigned int frames,
+                          unsigned int channels);
 };
 
 #endif // PLAYER_H

--- a/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
+++ b/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
@@ -34,9 +34,17 @@ distribution.
 
 namespace SoLoud
 {
+    typedef void (*miniaudio_output_capture_callback_t)(const float *samples, unsigned int frames, unsigned int channels, void *userData);
+
     result miniaudio_init(SoLoud::Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer)
     {
         return NOT_IMPLEMENTED;
+    }
+
+    void miniaudio_set_output_capture_callback(miniaudio_output_capture_callback_t callback, void *userData)
+    {
+        (void)callback;
+        (void)userData;
     }
 }
 
@@ -65,6 +73,7 @@ namespace SoLoud
 #ifdef __ANDROID__
 #include <android/api-level.h>
 #endif
+#include <atomic>
 #include <math.h>
 #include <chrono>
 #include <thread>
@@ -78,10 +87,14 @@ namespace SoLoud
 
 namespace SoLoud
 {
+    typedef void (*miniaudio_output_capture_callback_t)(const float *samples, unsigned int frames, unsigned int channels, void *userData);
+
     ma_device gDevice;
     SoLoud::Soloud *soloud;
     ma_context context;
     volatile bool gDeviceStopped = true;  // Track device stopped state for proper cleanup
+    static std::atomic<miniaudio_output_capture_callback_t> gOutputCaptureCallback{nullptr};
+    static std::atomic<void *> gOutputCaptureUserData{nullptr};
 
     // Forward declarations for functions used in on_notification
     result soloud_miniaudio_pause(SoLoud::Soloud *aSoloud);
@@ -186,6 +199,22 @@ namespace SoLoud
         first_call = false;
         SoLoud::Soloud *soloud = (SoLoud::Soloud *)pDevice->pUserData;
         soloud->mix((float *)pOutput, frameCount);
+
+        auto captureCallback = gOutputCaptureCallback.load(std::memory_order_acquire);
+        if (captureCallback != nullptr)
+        {
+            captureCallback(
+                (const float *)pOutput,
+                frameCount,
+                pDevice->playback.channels,
+                gOutputCaptureUserData.load(std::memory_order_acquire));
+        }
+    }
+
+    void miniaudio_set_output_capture_callback(miniaudio_output_capture_callback_t callback, void *userData)
+    {
+        gOutputCaptureUserData.store(userData, std::memory_order_release);
+        gOutputCaptureCallback.store(callback, std::memory_order_release);
     }
 
     static void soloud_miniaudio_deinit(SoLoud::Soloud *aSoloud)


### PR DESCRIPTION
## Description

Adds an opt-in API for capturing the final SoLoud mixed output as interleaved float32 PCM.

The capture point is in the miniaudio backend immediately after `soloud->mix(...)`, before the buffer is submitted to the playback device. This gives applications access to the same final master mix that is being played by the engine.

The implementation does not touch existing code, only new implementation that does not affect flutter_soloud if not enabled. Web returns `notImplemented` (not using miniaudio).

Public Dart API added:
- `SoLoud.instance.setOutputCaptureEnabled(...)`
- `SoLoud.instance.readOutputCapture(maxFrames)`
- `SoLoud.instance.getOutputCaptureAvailableFrames()`
- `SoLoud.instance.getOutputCaptureDroppedFrames()`
- `SoLoud.instance.getOutputCaptureFormat()`

Use cases include local streaming, recording, remote monitoring, remote playback, integrations, and external visualization/analysis.