### PR TITLE
Fix iOS CocoaPods wrapper double compile

### DIFF
--- a/ios/flutter_soloud.podspec
+++ b/ios/flutter_soloud.podspec
@@ -15,6 +15,11 @@ Flutter audio plugin using SoLoud library and FFI
 
   s.source           = { :path => '.' }
   s.source_files = 'flutter_soloud/Sources/flutter_soloud/*'
+  # flutter_soloud.mm is the SwiftPM wrapper that includes the full C++
+  # implementation. CocoaPods builds the same implementation through the
+  # CMake script phase below, so compiling the wrapper here defines duplicate
+  # symbols when the app also force-loads libflutter_soloud_plugin.a.
+  s.exclude_files = 'flutter_soloud/Sources/flutter_soloud/flutter_soloud.mm'
   s.dependency 'Flutter'
   s.platform = :ios, '13.0'
 


### PR DESCRIPTION
## Summary

- exclude the SwiftPM-only `flutter_soloud.mm` wrapper from the iOS CocoaPods target
- keep the CMake script phase as the single CocoaPods native implementation path
- avoid duplicate symbols when the app target force-loads `libflutter_soloud_plugin.a`

## Details

`flutter_soloud.mm` includes the full C++ implementation so SwiftPM can build the package from that wrapper source. The iOS CocoaPods podspec also builds the implementation through `build_cmake.sh` and then force-loads `libflutter_soloud_plugin.a` into the app target. When CocoaPods also compiles `flutter_soloud.mm`, the same implementation is present twice.

This keeps the wrapper file in the package for SwiftPM, but uses CocoaPods' `exclude_files` to keep it out of the CocoaPods compile sources.

## Validation

- `ruby -c ios/flutter_soloud.podspec`
- `pod ipc spec ios/flutter_soloud.podspec`
- `NO_XIPH_LIBS=1 pod ipc spec ios/flutter_soloud.podspec`
- local CocoaPods fixture with a stub `Flutter` pod: `pod install`, then verified generated `Pods.xcodeproj` references `miniaudio_objc_prefix.h` and `libflutter_soloud_plugin.a`, but no `flutter_soloud.mm`
