### PR TITLE
Add look-ahead brickwall limiter and fix planar DSP indexing

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -188,7 +188,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.4"
+    version: "4.0.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/filters/filters.dart
+++ b/lib/src/filters/filters.dart
@@ -522,7 +522,7 @@ enum FilterType {
     FilterType.robotizeFilter => 3,
     FilterType.freeverbFilter => 5,
     FilterType.pitchShiftFilter => 3,
-    FilterType.limiterFilter => 5,
+    FilterType.limiterFilter => 6,
     FilterType.compressorFilter => 8,
     FilterType.parametricEq => 67,
   };

--- a/lib/src/filters/limiter.dart
+++ b/lib/src/filters/limiter.dart
@@ -14,7 +14,7 @@ enum Limiter {
 
   final List<double> _mins = const [0, -60, -60, 0, 1, 0.1];
   final List<double> _maxs = const [1, 0, 0, 30, 1000, 200];
-  final List<double> _defs = const [1, -6, -1, 2, 100, 1];
+  final List<double> _defs = const [1, -3, -1, 2, 100, 1];
 
   double get min => _mins[index];
   double get max => _maxs[index];
@@ -23,7 +23,7 @@ enum Limiter {
   @override
   String toString() => switch (this) {
     Limiter.wet => 'Wet',
-    Limiter.threshold => 'Threshold',
+    Limiter.threshold => 'Threshold / Drive',
     Limiter.outputCeiling => 'Output Ceiling',
     Limiter.kneeWidth => 'Knee Width',
     Limiter.releaseTime => 'Release Time',

--- a/src/filters/compressor.cpp
+++ b/src/filters/compressor.cpp
@@ -42,7 +42,7 @@ void CompressorInstance::filter(
 
     for (unsigned int i = 0; i < aSamples; ++i) {
         for (unsigned int ch = 0; ch < aChannels; ++ch) {
-            float *sample = &aBuffer[i * aChannels + ch];
+            float *sample = &aBuffer[i + (size_t)ch * (size_t)aBufferSize];
             float inputLevel = fabsf(*sample);
 
             // Convert the input level to dB for comparison

--- a/src/filters/limiter.cpp
+++ b/src/filters/limiter.cpp
@@ -44,15 +44,13 @@ void LimiterInstance::filter(
 
     const float thresholdDb = mParam[Limiter::THRESHOLD];
     const float ceilingDb = mParam[Limiter::OUTPUT_CEILING];
-    const float kneeDb = mParam[Limiter::KNEE_WIDTH];
     const float wet = mParam[Limiter::WET];
     const float lookaheadMs = mParam[Limiter::ATTACK_TIME];
     const float releaseMs = mParam[Limiter::RELEASE_TIME];
 
     const float ceilingLin = powf(10.0f, ceilingDb / 20.0f);
-    const float halfKnee = kneeDb * 0.5f;
-    const float kneeLow = thresholdDb - halfKnee;
-    const float kneeHigh = thresholdDb + halfKnee;
+    const float driveDb = -thresholdDb;
+    const float driveLin = powf(10.0f, driveDb / 20.0f);
 
     // Look-ahead window in samples. Need at least 2 for a meaningful ramp.
     int desiredLookahead = (int)(lookaheadMs * 0.001f * aSamplerate + 0.5f);
@@ -76,28 +74,19 @@ void LimiterInstance::filter(
     const size_t stride = (size_t)aBufferSize;
 
     for (unsigned int i = 0; i < aSamples; ++i) {
-        // 1. Stereo-linked peak across all channels for this sample frame.
+        // 1. Stereo-linked driven peak across all channels for this sample frame.
         float peak = 0.0f;
         for (unsigned int ch = 0; ch < aChannels; ++ch) {
-            float a = fabsf(aBuffer[i + (size_t)ch * stride]);
+            float a = fabsf(aBuffer[i + (size_t)ch * stride]) * driveLin;
             if (a > peak) peak = a;
         }
 
-        // 2. Required gain reduction (dB), combining soft-knee threshold
-        //    behaviour with hard ceiling enforcement. Always pick the larger
-        //    reduction so the ceiling wins when in conflict.
+        // 2. Required gain reduction (dB) after maximizer drive. THRESHOLD is
+        //    interpreted as DAW-style limiter drive/autogain: -6 dB means
+        //    +6 dB into the brickwall. OUTPUT_CEILING is the only final peak
+        //    target.
         float peakDb = 20.0f * log10f(fmaxf(peak, 1e-8f));
-        float reductionDb = 0.0f;
-
-        if (kneeDb > 0.0f && peakDb > kneeLow && peakDb < kneeHigh) {
-            float over = peakDb - kneeLow;
-            reductionDb = (over * over) / (2.0f * kneeDb);
-        } else if (peakDb >= kneeHigh) {
-            reductionDb = peakDb - thresholdDb;
-        }
-
-        float ceilReductionDb = peakDb - ceilingDb;
-        if (ceilReductionDb > reductionDb) reductionDb = ceilReductionDb;
+        float reductionDb = peakDb - ceilingDb;
         if (reductionDb < 0.0f) reductionDb = 0.0f;
 
         float reqGain = powf(10.0f, -reductionDb / 20.0f);
@@ -154,7 +143,7 @@ void LimiterInstance::filter(
         //    net for any dry-path overshoot.
         for (unsigned int ch = 0; ch < aChannels; ++ch) {
             float dry = mDelayBuffer[(size_t)readPos * (size_t)aChannels + ch];
-            float limited = dry * mSmoothedGain;
+            float limited = dry * driveLin * mSmoothedGain;
             float out = wet * limited + (1.0f - wet) * dry;
             if (out > ceilingLin) out = ceilingLin;
             else if (out < -ceilingLin) out = -ceilingLin;
@@ -268,7 +257,7 @@ const char *Limiter::getParamName(unsigned int aParamIndex)
     case WET:
         return "Wet";
     case THRESHOLD:
-        return "Threshold";
+        return "Threshold / Drive";
     case OUTPUT_CEILING:
         return "Output Ceiling";
     case KNEE_WIDTH:
@@ -330,7 +319,7 @@ Limiter::Limiter(unsigned int aSamplerate)
 {
     mWet = 1.0f;
     mSamplerate = aSamplerate;
-    mThreshold = -6.0f;
+    mThreshold = -3.0f;
     mOutputCeiling = -1.0f;
     mKneeWidth = 6.0f;
     mReleaseTime = 50.0f;

--- a/src/filters/limiter.cpp
+++ b/src/filters/limiter.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <vector>
-#include <stdio.h>
 #include <cmath>
 
 LimiterInstance::LimiterInstance(Limiter *aParent)
@@ -16,14 +15,27 @@ LimiterInstance::LimiterInstance(Limiter *aParent)
     mParam[Limiter::RELEASE_TIME] = aParent->mReleaseTime;
     mParam[Limiter::ATTACK_TIME] = aParent->mAttackTime;
 
-    attackCoef = expf(-1.0f / (mParam[Limiter::ATTACK_TIME] * 0.001f * mParent->mSamplerate));
-    releaseCoef = expf(-1.0f / (mParam[Limiter::RELEASE_TIME] * 0.001f * mParent->mSamplerate));
+    mRingSize = 0;
+    mChannels = 0;
+    mWritePos = 0;
+    mSmoothedGain = 1.0f;
+    mReleaseCoef = 0.0f;
+}
+
+void LimiterInstance::resizeBuffers(int lookaheadSamples, int channels)
+{
+    mRingSize = lookaheadSamples;
+    mChannels = channels;
+    mDelayBuffer.assign((size_t)lookaheadSamples * (size_t)channels, 0.0f);
+    mGainEnv.assign((size_t)lookaheadSamples, 1.0f);
+    mWritePos = 0;
+    mSmoothedGain = 1.0f;
 }
 
 void LimiterInstance::filter(
     float *aBuffer,
     unsigned int aSamples,
-    unsigned int aBufferSize,
+    unsigned int /*aBufferSize*/,
     unsigned int aChannels,
     float aSamplerate,
     SoLoud::time aTime)
@@ -33,50 +45,119 @@ void LimiterInstance::filter(
     const float thresholdDb = mParam[Limiter::THRESHOLD];
     const float ceilingDb = mParam[Limiter::OUTPUT_CEILING];
     const float kneeDb = mParam[Limiter::KNEE_WIDTH];
+    const float wet = mParam[Limiter::WET];
+    const float lookaheadMs = mParam[Limiter::ATTACK_TIME];
+    const float releaseMs = mParam[Limiter::RELEASE_TIME];
 
-    // Initialize per-channel gain tracking if needed
-    if (mCurrentGain.size() != aChannels) {
-        mCurrentGain.resize(aChannels, 1.0f);
+    const float ceilingLin = powf(10.0f, ceilingDb / 20.0f);
+    const float halfKnee = kneeDb * 0.5f;
+    const float kneeLow = thresholdDb - halfKnee;
+    const float kneeHigh = thresholdDb + halfKnee;
+
+    // Look-ahead window in samples. Need at least 2 for a meaningful ramp.
+    int desiredLookahead = (int)(lookaheadMs * 0.001f * aSamplerate + 0.5f);
+    if (desiredLookahead < 2) desiredLookahead = 2;
+
+    if (mRingSize != desiredLookahead || mChannels != (int)aChannels) {
+        resizeBuffers(desiredLookahead, (int)aChannels);
     }
 
+    // One-pole release coefficient. Recomputed every call: cheap, and tracks
+    // parameter changes without a click.
+    mReleaseCoef = expf(-1.0f / fmaxf(releaseMs * 0.001f * aSamplerate, 1.0f));
+
+    const int ringSize = mRingSize;
+    const float perStepBase = 1.0f / (float)(ringSize - 1);
+
     for (unsigned int i = 0; i < aSamples; ++i) {
+        // 1. Stereo-linked peak across all channels for this sample frame.
+        float peak = 0.0f;
         for (unsigned int ch = 0; ch < aChannels; ++ch) {
-            float* sample = &aBuffer[i * aChannels + ch];
-            float inputAbs = fabsf(*sample);
+            float a = fabsf(aBuffer[i * aChannels + ch]);
+            if (a > peak) peak = a;
+        }
 
-            // Calculate input level in dB
-            float inputDb = 20.0f * log10f(fmaxf(inputAbs, 1e-8f));
+        // 2. Required gain reduction (dB), combining soft-knee threshold
+        //    behaviour with hard ceiling enforcement. Always pick the larger
+        //    reduction so the ceiling wins when in conflict.
+        float peakDb = 20.0f * log10f(fmaxf(peak, 1e-8f));
+        float reductionDb = 0.0f;
 
-            float gainReductionDb = 0.0f;
-            if (inputDb > (thresholdDb - kneeDb / 2.0f)) {
-                if (kneeDb > 0 && inputDb < (thresholdDb + kneeDb / 2.0f)) {
-                    // Soft knee
-                    float x = inputDb - thresholdDb + kneeDb / 2.0f;
-                    gainReductionDb = (x * x) / (2.0f * kneeDb);
+        if (kneeDb > 0.0f && peakDb > kneeLow && peakDb < kneeHigh) {
+            float over = peakDb - kneeLow;
+            reductionDb = (over * over) / (2.0f * kneeDb);
+        } else if (peakDb >= kneeHigh) {
+            reductionDb = peakDb - thresholdDb;
+        }
+
+        float ceilReductionDb = peakDb - ceilingDb;
+        if (ceilReductionDb > reductionDb) reductionDb = ceilReductionDb;
+        if (reductionDb < 0.0f) reductionDb = 0.0f;
+
+        float reqGain = powf(10.0f, -reductionDb / 20.0f);
+        if (reqGain > 1.0f) reqGain = 1.0f;
+
+        // 3. Write the new sample frame and its required gain into the ring.
+        for (unsigned int ch = 0; ch < aChannels; ++ch) {
+            mDelayBuffer[(size_t)mWritePos * (size_t)aChannels + ch] =
+                aBuffer[i * aChannels + ch];
+        }
+        mGainEnv[mWritePos] = reqGain;
+
+        // 4. Backward scan: walk back through the look-ahead window and lower
+        //    any earlier required-gain values that would not allow a smooth
+        //    linear ramp down to reqGain by the time it reaches the output.
+        //    This is what makes the limiter "look ahead" — it pre-emptively
+        //    starts ramping the gain down so the offending sample arrives
+        //    already attenuated, instead of being clipped after the fact.
+        if (reqGain < 1.0f) {
+            float perStep = (1.0f - reqGain) * perStepBase;
+            float threshGain = reqGain;
+            for (int back = 1; back < ringSize; ++back) {
+                threshGain += perStep;
+                if (threshGain >= 1.0f) break;
+                int idx = mWritePos - back;
+                if (idx < 0) idx += ringSize;
+                if (mGainEnv[idx] > threshGain) {
+                    mGainEnv[idx] = threshGain;
                 } else {
-                    // Hard knee (limiter)
-                    gainReductionDb = inputDb - thresholdDb;
+                    // The earlier sample already demands an equal or lower
+                    // gain; its own backward scan covers everything before it.
+                    break;
                 }
             }
-
-            // Apply ceiling
-            gainReductionDb = fmaxf(gainReductionDb, inputDb - ceilingDb);
-
-            float targetGain = powf(10.0f, -gainReductionDb / 20.0f);
-
-            // Smooth gain changes
-            if (targetGain < mCurrentGain[ch]) {
-                // Attack phase
-                mCurrentGain[ch] = attackCoef * mCurrentGain[ch] + (1.0f - attackCoef) * targetGain;
-            } else {
-                // Release phase
-                mCurrentGain[ch] = releaseCoef * mCurrentGain[ch] + (1.0f - releaseCoef) * targetGain;
-            }
-
-            // Apply the gain and wet/dry mix
-            float limitedSample = *sample * mCurrentGain[ch];
-            *sample = (mParam[Limiter::WET] * limitedSample) + ((1.0f - mParam[Limiter::WET]) * *sample);
         }
+
+        // 5. Read the oldest frame in the ring (the one being emitted now).
+        int readPos = mWritePos + 1;
+        if (readPos >= ringSize) readPos = 0;
+        float envGain = mGainEnv[readPos];
+
+        // 6. Release smoothing only. Attack is encoded in the envelope ramp,
+        //    so going DOWN tracks the envelope sample-accurately; going UP
+        //    is smoothed by the one-pole release filter.
+        if (envGain >= mSmoothedGain) {
+            mSmoothedGain = mReleaseCoef * mSmoothedGain +
+                            (1.0f - mReleaseCoef) * envGain;
+        } else {
+            mSmoothedGain = envGain;
+        }
+
+        // 7. Apply gain to the delayed sample, mix wet/dry (both delayed so
+        //    they stay phase-aligned), and hard-clip at ceiling as a safety
+        //    net for any dry-path overshoot.
+        for (unsigned int ch = 0; ch < aChannels; ++ch) {
+            float dry = mDelayBuffer[(size_t)readPos * (size_t)aChannels + ch];
+            float limited = dry * mSmoothedGain;
+            float out = wet * limited + (1.0f - wet) * dry;
+            if (out > ceilingLin) out = ceilingLin;
+            else if (out < -ceilingLin) out = -ceilingLin;
+            aBuffer[i * aChannels + ch] = out;
+        }
+
+        // 8. Advance the write head.
+        mWritePos++;
+        if (mWritePos >= ringSize) mWritePos = 0;
     }
 }
 
@@ -117,14 +198,14 @@ void LimiterInstance::setFilterParameter(unsigned int aAttributeId, float aValue
             aValue > mParent->getParamMax(Limiter::RELEASE_TIME))
             return;
         mParam[Limiter::RELEASE_TIME] = aValue;
-        releaseCoef = expf(-1.0f / (mParam[Limiter::RELEASE_TIME] * 0.001f * mParent->mSamplerate));
         break;
     case Limiter::ATTACK_TIME:
         if (aValue < mParent->getParamMin(Limiter::ATTACK_TIME) ||
             aValue > mParent->getParamMax(Limiter::ATTACK_TIME))
             return;
         mParam[Limiter::ATTACK_TIME] = aValue;
-        attackCoef = expf(-1.0f / (mParam[Limiter::ATTACK_TIME] * 0.001f * mParent->mSamplerate));
+        // The look-ahead ring is resized lazily in filter() the next time it
+        // runs — avoids a click on every parameter touch.
         break;
     }
 
@@ -189,12 +270,12 @@ const char *Limiter::getParamName(unsigned int aParamIndex)
     case RELEASE_TIME:
         return "Release Time";
     case ATTACK_TIME:
-        return "Attack Time";
+        return "Lookahead";
     }
     return "Wet";
 }
 
-unsigned int Limiter::getParamType(unsigned int aParamIndex)
+unsigned int Limiter::getParamType(unsigned int /*aParamIndex*/)
 {
     return FLOAT_PARAM;
 }
@@ -245,9 +326,9 @@ Limiter::Limiter(unsigned int aSamplerate)
     mSamplerate = aSamplerate;
     mThreshold = -6.0f;
     mOutputCeiling = -1.0f;
-    mKneeWidth = 6.0f;    // Wider knee for smoother transition
-    mReleaseTime = 50.0f; // Faster release
-    mAttackTime = 1.0f;   // Fast attack to catch peaks
+    mKneeWidth = 6.0f;
+    mReleaseTime = 50.0f;
+    mAttackTime = 1.0f; // 1 ms look-ahead = 48 samples @ 48 kHz
 }
 
 SoLoud::FilterInstance *Limiter::createInstance()

--- a/src/filters/limiter.cpp
+++ b/src/filters/limiter.cpp
@@ -35,7 +35,7 @@ void LimiterInstance::resizeBuffers(int lookaheadSamples, int channels)
 void LimiterInstance::filter(
     float *aBuffer,
     unsigned int aSamples,
-    unsigned int /*aBufferSize*/,
+    unsigned int aBufferSize,
     unsigned int aChannels,
     float aSamplerate,
     SoLoud::time aTime)
@@ -69,11 +69,17 @@ void LimiterInstance::filter(
     const int ringSize = mRingSize;
     const float perStepBase = 1.0f / (float)(ringSize - 1);
 
+    // SoLoud passes audio in PLANAR layout: channel ch occupies the contiguous
+    // range [ch*aBufferSize, ch*aBufferSize + aSamples). The internal delay
+    // buffer remains frame-major (channel-interleaved) for cache locality of
+    // the per-frame read/write.
+    const size_t stride = (size_t)aBufferSize;
+
     for (unsigned int i = 0; i < aSamples; ++i) {
         // 1. Stereo-linked peak across all channels for this sample frame.
         float peak = 0.0f;
         for (unsigned int ch = 0; ch < aChannels; ++ch) {
-            float a = fabsf(aBuffer[i * aChannels + ch]);
+            float a = fabsf(aBuffer[i + (size_t)ch * stride]);
             if (a > peak) peak = a;
         }
 
@@ -100,7 +106,7 @@ void LimiterInstance::filter(
         // 3. Write the new sample frame and its required gain into the ring.
         for (unsigned int ch = 0; ch < aChannels; ++ch) {
             mDelayBuffer[(size_t)mWritePos * (size_t)aChannels + ch] =
-                aBuffer[i * aChannels + ch];
+                aBuffer[i + (size_t)ch * stride];
         }
         mGainEnv[mWritePos] = reqGain;
 
@@ -152,7 +158,7 @@ void LimiterInstance::filter(
             float out = wet * limited + (1.0f - wet) * dry;
             if (out > ceilingLin) out = ceilingLin;
             else if (out < -ceilingLin) out = -ceilingLin;
-            aBuffer[i * aChannels + ch] = out;
+            aBuffer[i + (size_t)ch * stride] = out;
         }
 
         // 8. Advance the write head.

--- a/src/filters/limiter.h
+++ b/src/filters/limiter.h
@@ -6,12 +6,14 @@
 
 class Limiter;
 
-// True look-ahead brick-wall peak limiter.
+// True look-ahead brick-wall limiter/maximizer.
 //
 // Replaces the original feed-forward soft-knee compressor that smoothed the
 // gain envelope AFTER computing the required reduction (which let transients
 // leak through the "ceiling"). The new implementation:
 //
+//   * applies THRESHOLD as DAW-style drive/autogain (-6 dB = +6 dB into the
+//     limiter), while OUTPUT_CEILING remains the final brickwall level;
 //   * delays the audio by ATTACK_TIME (now interpreted as a look-ahead
 //     window in milliseconds) so the gain has time to ramp DOWN to the
 //     required value BEFORE the offending sample is emitted;
@@ -67,9 +69,9 @@ public:
   };
   unsigned int mSamplerate;
   float mWet;           // wet/dry mix, 1.0 = fully limited, 0.0 = bypass
-  float mThreshold;     // dB at which gain reduction starts (knee centred here)
+  float mThreshold;     // dB drive/autogain control: -6 dB means +6 dB drive
   float mOutputCeiling; // dB hard maximum output (guaranteed)
-  float mKneeWidth;     // dB width of the soft-knee transition into limiting
+  float mKneeWidth;     // retained for API compatibility; unused by maximizer
   float mReleaseTime;   // ms one-pole release time constant
   float mAttackTime;    // ms look-ahead window length (was: envelope attack)
 

--- a/src/filters/limiter.h
+++ b/src/filters/limiter.h
@@ -6,11 +6,45 @@
 
 class Limiter;
 
+// True look-ahead brick-wall peak limiter.
+//
+// Replaces the original feed-forward soft-knee compressor that smoothed the
+// gain envelope AFTER computing the required reduction (which let transients
+// leak through the "ceiling"). The new implementation:
+//
+//   * delays the audio by ATTACK_TIME (now interpreted as a look-ahead
+//     window in milliseconds) so the gain has time to ramp DOWN to the
+//     required value BEFORE the offending sample is emitted;
+//   * uses a stereo-linked peak detector (max across channels) so the
+//     stereo image stays stable on transients;
+//   * walks the gain envelope backward across the look-ahead window with a
+//     linear attack ramp, guaranteeing that the gain at output position
+//     equals the required reduction;
+//   * applies a one-pole release smoother (attack is instantaneous via the
+//     envelope; only release is smoothed);
+//   * hard-clips the post-mix output at the ceiling as a safety net so the
+//     output is mathematically guaranteed to stay <= ceiling even when the
+//     wet/dry mix introduces dry-path overshoot.
+//
+// Public parameter IDs and ranges are unchanged so the Dart wrapper and
+// existing presets continue to work. The semantic of ATTACK_TIME shifts
+// from "envelope smoothing time constant" to "look-ahead window length";
+// in practice the typical value (1 ms) means the same thing to the user.
 class LimiterInstance : public SoLoud::FilterInstance {
   Limiter *mParent;
-  std::vector<float> mCurrentGain; // Store gain per channel
-  float attackCoef;
-  float releaseCoef;
+
+  // Ring buffer holding delayed audio: size = mRingSize * mChannels
+  std::vector<float> mDelayBuffer;
+  // Ring buffer holding the per-sample required gain envelope: size = mRingSize
+  std::vector<float> mGainEnv;
+
+  int mRingSize;       // look-ahead in samples
+  int mChannels;       // cached channel count
+  int mWritePos;       // ring index for the newest sample
+  float mSmoothedGain; // gain after release smoothing
+  float mReleaseCoef;  // one-pole release coefficient (recomputed per block)
+
+  void resizeBuffers(int lookaheadSamples, int channels);
 
 public:
   virtual void filter(float *aBuffer, unsigned int aSamples,
@@ -32,17 +66,12 @@ public:
     ATTACK_TIME = 5
   };
   unsigned int mSamplerate;
-  float mWet; // Wet/dry mix ratio, 1.0 means fully wet, 0.0 means fully dry
-  float mThreshold; // The threshold in dB. Signals above this level are reduced
-                    // in gain. A lower value means more aggressive limiting.
-  float mOutputCeiling; // The maximum output level in dB (should be < 0dB to
-                        // prevent clipping)
-  float mKneeWidth; // The width of the knee in dB. A larger value results in a
-                    // softer transition into limiting.
-  float mReleaseTime; // The release time in milliseconds. Determines how
-                      // quickly the gain reduction recovers after a signal
-                      // drops below the threshold.
-  float mAttackTime;  // Attack time in milliseconds
+  float mWet;           // wet/dry mix, 1.0 = fully limited, 0.0 = bypass
+  float mThreshold;     // dB at which gain reduction starts (knee centred here)
+  float mOutputCeiling; // dB hard maximum output (guaranteed)
+  float mKneeWidth;     // dB width of the soft-knee transition into limiting
+  float mReleaseTime;   // ms one-pole release time constant
+  float mAttackTime;    // ms look-ahead window length (was: envelope attack)
 
   virtual int getParamCount();
   virtual const char *getParamName(unsigned int aParamIndex);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -97,8 +97,12 @@ PlayerErrors Player::init(unsigned int sampleRate, unsigned int bufferSize, unsi
     SoLoud::result result;
     try {
         result = soloud.init(
-            SoLoud::Soloud::CLIP_ROUNDOFF,
+            0,
             SoLoud::Soloud::MINIAUDIO, sampleRate, bufferSize, channels, playbackInfos_id);
+        if (result == SoLoud::SO_NO_ERROR)
+        {
+            soloud.setPostClipScaler(1.0f);
+        }
     } catch (...) {
         return backendNotInited;
     }

--- a/test/limiter_test.cpp
+++ b/test/limiter_test.cpp
@@ -119,10 +119,21 @@ struct LimiterRig {
     }
     ~LimiterRig() { delete inst; }
 
+    // Buffers are planar: channel ch lives at [ch*frames, ch*frames + frames).
     void run(float* buf, unsigned int frames, unsigned int channels) {
         inst->filter(buf, frames, frames, channels, SAMPLERATE, 0.0);
     }
 };
+
+// Helpers to read/write planar stereo buffers in the test.
+static inline float& planar(std::vector<float>& buf, unsigned int frames,
+                            unsigned int frameIdx, unsigned int ch) {
+    return buf[(size_t)ch * frames + frameIdx];
+}
+static inline float planarRead(const std::vector<float>& buf, unsigned int frames,
+                               unsigned int frameIdx, unsigned int ch) {
+    return buf[(size_t)ch * frames + frameIdx];
+}
 
 // Allow a tiny float tolerance above the ceiling for cumulative FP error.
 constexpr float CEILING_EPS = 1e-5f;
@@ -146,9 +157,9 @@ static void testCeilingHonoredOnImpulse() {
     constexpr unsigned int CHANNELS = 2;
     constexpr unsigned int FRAMES = 4096;
     std::vector<float> buf(FRAMES * CHANNELS, 0.0f);
-    // Full-scale spike on both channels at frame 100.
-    buf[100 * CHANNELS + 0] = 1.0f;
-    buf[100 * CHANNELS + 1] = 1.0f;
+    // Full-scale spike on both channels at frame 100 (planar).
+    planar(buf, FRAMES, 100, 0) = 1.0f;
+    planar(buf, FRAMES, 100, 1) = 1.0f;
 
     rig.run(buf.data(), FRAMES, CHANNELS);
 
@@ -170,16 +181,20 @@ static void testCeilingHonoredOnLoudSine() {
     const float amp = 2.0f; // +6 dB above 0 dBFS
     for (unsigned int i = 0; i < FRAMES; ++i) {
         float v = amp * std::sin(2.0f * (float)M_PI * freq * (float)i / SAMPLERATE);
-        buf[i * CHANNELS + 0] = v;
-        buf[i * CHANNELS + 1] = v;
+        planar(buf, FRAMES, i, 0) = v;
+        planar(buf, FRAMES, i, 1) = v;
     }
 
     rig.run(buf.data(), FRAMES, CHANNELS);
 
-    // Skip the lookahead priming region (first ~50 samples) when measuring.
+    // Skip the lookahead priming region when measuring.
     const size_t startFrame = 200;
-    float peak = maxAbs(buf.data() + startFrame * CHANNELS,
-                        (FRAMES - startFrame) * CHANNELS);
+    float peakL = 0.f, peakR = 0.f;
+    for (size_t i = startFrame; i < FRAMES; ++i) {
+        peakL = std::max(peakL, std::fabs(planarRead(buf, FRAMES, i, 0)));
+        peakR = std::max(peakR, std::fabs(planarRead(buf, FRAMES, i, 1)));
+    }
+    float peak = std::max(peakL, peakR);
     EXPECT(peak <= rig.ceilingLin + CEILING_EPS,
            "peak %.6f > ceiling %.6f", peak, rig.ceilingLin);
     std::printf("    steady-state peak: %.6f (ceiling %.6f)\n", peak, rig.ceilingLin);
@@ -198,8 +213,8 @@ static void testQuietPassesThrough() {
     const float amp = 0.1f; // -20 dB, well below -6 dB threshold knee
     for (unsigned int i = 0; i < FRAMES; ++i) {
         float v = amp * std::sin(2.0f * (float)M_PI * freq * (float)i / SAMPLERATE);
-        in[i * CHANNELS + 0] = v;
-        in[i * CHANNELS + 1] = v;
+        planar(in, FRAMES, i, 0) = v;
+        planar(in, FRAMES, i, 1) = v;
     }
     std::vector<float> buf = in;
     rig.run(buf.data(), FRAMES, CHANNELS);
@@ -211,7 +226,8 @@ static void testQuietPassesThrough() {
     float maxErr = 0.f;
     for (unsigned int i = delay; i < FRAMES; ++i) {
         for (unsigned int c = 0; c < CHANNELS; ++c) {
-            float err = std::fabs(buf[i * CHANNELS + c] - in[(i - delay) * CHANNELS + c]);
+            float err = std::fabs(planarRead(buf, FRAMES, i, c) -
+                                  planarRead(in, FRAMES, i - delay, c));
             if (err > maxErr) maxErr = err;
         }
     }
@@ -233,8 +249,8 @@ static void testStereoLinked() {
     const float freq = 1000.0f;
     for (unsigned int i = 0; i < FRAMES; ++i) {
         float t = 2.0f * (float)M_PI * freq * (float)i / SAMPLERATE;
-        buf[i * CHANNELS + 0] = ampL * std::sin(t);
-        buf[i * CHANNELS + 1] = ampR * std::sin(t);
+        planar(buf, FRAMES, i, 0) = ampL * std::sin(t);
+        planar(buf, FRAMES, i, 1) = ampR * std::sin(t);
     }
     rig.run(buf.data(), FRAMES, CHANNELS);
 
@@ -243,8 +259,8 @@ static void testStereoLinked() {
     const size_t startFrame = 200;
     float peakL = 0.f, peakR = 0.f;
     for (size_t i = startFrame; i < FRAMES; ++i) {
-        peakL = std::max(peakL, std::fabs(buf[i * CHANNELS + 0]));
-        peakR = std::max(peakR, std::fabs(buf[i * CHANNELS + 1]));
+        peakL = std::max(peakL, std::fabs(planarRead(buf, FRAMES, i, 0)));
+        peakR = std::max(peakR, std::fabs(planarRead(buf, FRAMES, i, 1)));
     }
     float ratio = peakL / std::max(peakR, 1e-9f);
     float expectedRatio = ampL / ampR; // 3.0
@@ -284,11 +300,17 @@ static void testCeilingHonoredUnderFuzz() {
         }
         rig.run(buf.data(), FRAMES, CHANNELS);
 
-        // Skip the lookahead window for the peak measurement.
+        // Skip the lookahead window for the peak measurement (planar: skip
+        // the first `look` frames in each channel slab).
         const unsigned int look = std::max(2u,
             (unsigned int)(p.attack * 0.001f * SAMPLERATE + 0.5f));
-        float peak = maxAbs(buf.data() + look * CHANNELS,
-                            (FRAMES - look) * CHANNELS);
+        float peak = 0.f;
+        for (unsigned int c = 0; c < CHANNELS; ++c) {
+            for (unsigned int i = look; i < FRAMES; ++i) {
+                float a = std::fabs(planarRead(buf, FRAMES, i, c));
+                if (a > peak) peak = a;
+            }
+        }
         EXPECT(peak <= rig.ceilingLin + CEILING_EPS,
                "thr=%.1f ceil=%.2f knee=%.1f rel=%.0f atk=%.1f -> peak %.6f > ceil %.6f",
                p.threshold, p.ceiling, p.knee, p.release, p.attack, peak, rig.ceilingLin);
@@ -345,6 +367,45 @@ static void testLookaheadRampPrecedesPeak() {
                 farBeforeSample, preSpike, spikeOut, rig.ceilingLin);
 }
 
+// 7. Regression test for the planar-vs-interleaved buffer layout bug.
+//    SoLoud passes audio in PLANAR layout: channel ch occupies the contiguous
+//    range [ch*aBufferSize, ch*aBufferSize + aSamples). If the limiter
+//    indexes the buffer as interleaved, samples get scrambled across
+//    channels and the output is heavy distortion.
+//
+//    To catch this: feed two completely different signals into L and R
+//    (1 kHz sine into L, 7 kHz sine into R, both BELOW threshold so no
+//    limiting kicks in) and verify each output channel matches its OWN
+//    delayed input — no cross-channel bleed.
+static void testPlanarLayoutNoCrossChannelBleed() {
+    std::printf("Test: planar buffer layout — no cross-channel bleed\n");
+    LimiterRig rig;
+    constexpr unsigned int CHANNELS = 2;
+    constexpr unsigned int FRAMES = 2048;
+    std::vector<float> in(FRAMES * CHANNELS, 0.0f);
+    const float ampL = 0.1f, freqL = 1000.0f; // L: 1 kHz quiet
+    const float ampR = 0.1f, freqR = 7000.0f; // R: 7 kHz quiet (well below thr)
+    for (unsigned int i = 0; i < FRAMES; ++i) {
+        planar(in, FRAMES, i, 0) = ampL * std::sin(2.0f * (float)M_PI * freqL * (float)i / SAMPLERATE);
+        planar(in, FRAMES, i, 1) = ampR * std::sin(2.0f * (float)M_PI * freqR * (float)i / SAMPLERATE);
+    }
+    std::vector<float> buf = in;
+    rig.run(buf.data(), FRAMES, CHANNELS);
+
+    const unsigned int delay = (unsigned int)(1.0f * 0.001f * SAMPLERATE + 0.5f) - 1;
+    float maxErrL = 0.f, maxErrR = 0.f;
+    for (unsigned int i = delay; i < FRAMES; ++i) {
+        maxErrL = std::max(maxErrL, std::fabs(planarRead(buf, FRAMES, i, 0) -
+                                              planarRead(in, FRAMES, i - delay, 0)));
+        maxErrR = std::max(maxErrR, std::fabs(planarRead(buf, FRAMES, i, 1) -
+                                              planarRead(in, FRAMES, i - delay, 1)));
+    }
+    EXPECT(maxErrL < 1e-5f, "L channel corrupted, err = %.3e", maxErrL);
+    EXPECT(maxErrR < 1e-5f, "R channel corrupted, err = %.3e", maxErrR);
+    std::printf("    max err L=%.3e, R=%.3e (both below threshold, expect identity)\n",
+                maxErrL, maxErrR);
+}
+
 // ---- main -----------------------------------------------------------------
 
 int main() {
@@ -356,6 +417,7 @@ int main() {
     testStereoLinked();
     testCeilingHonoredUnderFuzz();
     testLookaheadRampPrecedesPeak();
+    testPlanarLayoutNoCrossChannelBleed();
 
     std::printf("\n%d/%d assertions passed, %d failures\n",
                 g_assertions - g_failures, g_assertions, g_failures);

--- a/test/limiter_test.cpp
+++ b/test/limiter_test.cpp
@@ -91,8 +91,7 @@ static int g_assertions = 0;
 
 constexpr float SAMPLERATE = 48000.0f;
 
-// Build a fresh limiter with the given parameters (defaults match the
-// gphil-flutter app's audio_effects_snapshot.dart).
+// Build a fresh limiter with maximizer-style defaults.
 struct LimiterRig {
     Limiter parent;
     LimiterInstance* inst;
@@ -101,7 +100,7 @@ struct LimiterRig {
 
     explicit LimiterRig(
         float wet = 1.0f,
-        float thresholdDb = -6.0f,
+        float thresholdDb = -3.0f,
         float ceilingDb = -1.0f,
         float kneeDb = 6.0f,
         float releaseMs = 50.0f,
@@ -200,11 +199,10 @@ static void testCeilingHonoredOnLoudSine() {
     std::printf("    steady-state peak: %.6f (ceiling %.6f)\n", peak, rig.ceilingLin);
 }
 
-// 3. Quiet input below threshold should pass through at unity gain (after
-//    the lookahead delay). This catches accidental gain reduction on signals
-//    that shouldn't trigger any limiting.
-static void testQuietPassesThrough() {
-    std::printf("Test: -20 dB sine passes through at unity gain\n");
+// 3. Quiet input below the output ceiling should pass through with maximizer
+//    drive (after the lookahead delay), without extra gain reduction.
+static void testQuietGetsMaximizerDrive() {
+    std::printf("Test: -20 dB sine gets threshold autogain\n");
     LimiterRig rig;
     constexpr unsigned int CHANNELS = 2;
     constexpr unsigned int FRAMES = (unsigned int)(SAMPLERATE * 0.05f); // 50 ms
@@ -219,20 +217,22 @@ static void testQuietPassesThrough() {
     std::vector<float> buf = in;
     rig.run(buf.data(), FRAMES, CHANNELS);
 
+    const float driveLin = std::pow(10.0f, -rig.parent.mThreshold / 20.0f);
+
     // Internal delay = ringSize - 1 = lookaheadSamples - 1 samples. After
-    // priming, output[i] should equal input[i - delay] sample-accurately.
+    // priming, output[i] should equal driven input[i - delay] sample-accurately.
     const unsigned int lookahead = (unsigned int)(1.0f * 0.001f * SAMPLERATE + 0.5f);
     const unsigned int delay = lookahead - 1;
     float maxErr = 0.f;
     for (unsigned int i = delay; i < FRAMES; ++i) {
         for (unsigned int c = 0; c < CHANNELS; ++c) {
             float err = std::fabs(planarRead(buf, FRAMES, i, c) -
-                                  planarRead(in, FRAMES, i - delay, c));
+                                  planarRead(in, FRAMES, i - delay, c) * driveLin);
             if (err > maxErr) maxErr = err;
         }
     }
-    EXPECT(maxErr < 1e-6f, "quiet signal altered, max sample error = %.3e", maxErr);
-    std::printf("    max sample error vs delayed input: %.3e\n", maxErr);
+    EXPECT(maxErr < 1e-6f, "quiet signal not driven cleanly, max sample error = %.3e", maxErr);
+    std::printf("    max sample error vs delayed driven input: %.3e\n", maxErr);
 }
 
 // 4. Stereo-linked gain — asymmetric L/R input should preserve the L:R
@@ -326,7 +326,7 @@ static void testCeilingHonoredUnderFuzz() {
 //    gain down BEFORE the peak arrived, not after.
 static void testLookaheadRampPrecedesPeak() {
     std::printf("Test: gain ramps DOWN before the peak (true look-ahead)\n");
-    // threshold = ceiling so the spike output should land exactly on ceiling.
+    // With -1 dB threshold, the maximizer applies +1 dB drive before limiting.
     LimiterRig rig(1.0f, -1.0f, -1.0f, 0.0f, 50.0f, 2.0f /*2 ms look-ahead*/);
     constexpr unsigned int CHANNELS = 1;
     constexpr unsigned int FRAMES = 4096;
@@ -349,18 +349,18 @@ static void testLookaheadRampPrecedesPeak() {
            "spike fell well below ceiling — limiter overreacting? %.6f vs %.6f",
            spikeOut, rig.ceilingLin);
 
-    // Sample emitted RIGHT before the spike: tone (0.5) attenuated by the
-    // ramp. Required gain at the spike is ceiling/4 ≈ 0.223, so the sample
-    // one step before should be ~0.223 + (1-0.223)/lookahead, applied to 0.5.
+    // Sample emitted RIGHT before the spike: driven tone attenuated by the
+    // ramp. Required gain at the spike is ceiling/(4 dB driven by +1 dB).
     float preSpike = std::fabs(buf[outSpikeIdx - 1]);
-    EXPECT(preSpike < 0.4f,
+    EXPECT(preSpike < 0.45f,
            "no pre-emptive gain reduction before peak: pre-spike sample = %.4f", preSpike);
 
     // And a sample well before the look-ahead window started attenuating:
-    // should still be at full 0.5 (the tone, unmodified).
+    // should still be the tone with maximizer drive applied.
     const unsigned int farBefore = outSpikeIdx - lookahead - 200;
     float farBeforeSample = std::fabs(buf[farBefore]);
-    EXPECT(farBeforeSample > 0.49f && farBeforeSample < 0.51f,
+    const float drivenTone = 0.5f * std::pow(10.0f, 1.0f / 20.0f);
+    EXPECT(std::fabs(farBeforeSample - drivenTone) < 1e-5f,
            "tone was attenuated outside the lookahead window: %.4f", farBeforeSample);
 
     std::printf("    far-before %.4f, pre-spike %.4f, spike %.4f (ceiling %.4f)\n",
@@ -374,9 +374,9 @@ static void testLookaheadRampPrecedesPeak() {
 //    channels and the output is heavy distortion.
 //
 //    To catch this: feed two completely different signals into L and R
-//    (1 kHz sine into L, 7 kHz sine into R, both BELOW threshold so no
-//    limiting kicks in) and verify each output channel matches its OWN
-//    delayed input — no cross-channel bleed.
+//    (1 kHz sine into L, 7 kHz sine into R, both below the output ceiling
+//    after drive) and verify each output channel matches its OWN delayed,
+//    driven input — no cross-channel bleed.
 static void testPlanarLayoutNoCrossChannelBleed() {
     std::printf("Test: planar buffer layout — no cross-channel bleed\n");
     LimiterRig rig;
@@ -393,16 +393,17 @@ static void testPlanarLayoutNoCrossChannelBleed() {
     rig.run(buf.data(), FRAMES, CHANNELS);
 
     const unsigned int delay = (unsigned int)(1.0f * 0.001f * SAMPLERATE + 0.5f) - 1;
+    const float driveLin = std::pow(10.0f, -rig.parent.mThreshold / 20.0f);
     float maxErrL = 0.f, maxErrR = 0.f;
     for (unsigned int i = delay; i < FRAMES; ++i) {
         maxErrL = std::max(maxErrL, std::fabs(planarRead(buf, FRAMES, i, 0) -
-                                              planarRead(in, FRAMES, i - delay, 0)));
+                                              planarRead(in, FRAMES, i - delay, 0) * driveLin));
         maxErrR = std::max(maxErrR, std::fabs(planarRead(buf, FRAMES, i, 1) -
-                                              planarRead(in, FRAMES, i - delay, 1)));
+                                              planarRead(in, FRAMES, i - delay, 1) * driveLin));
     }
     EXPECT(maxErrL < 1e-5f, "L channel corrupted, err = %.3e", maxErrL);
     EXPECT(maxErrR < 1e-5f, "R channel corrupted, err = %.3e", maxErrR);
-    std::printf("    max err L=%.3e, R=%.3e (both below threshold, expect identity)\n",
+    std::printf("    max err L=%.3e, R=%.3e (both below ceiling, expect driven identity)\n",
                 maxErrL, maxErrR);
 }
 
@@ -413,7 +414,7 @@ int main() {
 
     testCeilingHonoredOnImpulse();
     testCeilingHonoredOnLoudSine();
-    testQuietPassesThrough();
+    testQuietGetsMaximizerDrive();
     testStereoLinked();
     testCeilingHonoredUnderFuzz();
     testLookaheadRampPrecedesPeak();

--- a/test/limiter_test.cpp
+++ b/test/limiter_test.cpp
@@ -1,0 +1,363 @@
+// Standalone correctness tests for the look-ahead brick-wall limiter.
+//
+// Build & run from the flutter_soloud repo root:
+//
+//   c++ -std=c++17 -O2 -Wall \
+//       -I src/soloud/include \
+//       -o /tmp/limiter_test \
+//       test/limiter_test.cpp src/filters/limiter.cpp \
+//   && /tmp/limiter_test
+//
+// Or use the convenience wrapper:
+//
+//   ./test/run_limiter_test.sh
+//
+// Tests live in this file. SoLoud base classes are stubbed below so the
+// limiter can be exercised without linking the full SoLoud engine.
+
+#include "../src/filters/limiter.h"
+#include "../src/soloud/include/soloud_filter.h"
+#include "../src/soloud/include/soloud_fader.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+// ---- SoLoud stubs ---------------------------------------------------------
+// Minimal symbol implementations so the linker is happy without pulling in
+// the rest of the SoLoud engine. None of these stubs are exercised by the
+// limiter beyond what's noted.
+
+namespace SoLoud {
+
+Fader::Fader() {
+    mFrom = 0; mTo = 0; mDelta = 0;
+    mTime = 0; mStartTime = 0; mEndTime = 0;
+    mCurrent = 0; mActive = 0;
+}
+void Fader::setLFO(float, float, time, time) {}
+void Fader::set(float, float, time, time) {}
+float Fader::get(time) { return mCurrent; }
+
+FilterInstance::FilterInstance() {
+    mNumParams = 0;
+    mParamChanged = 0;
+    mParam = nullptr;
+    mParamFader = nullptr;
+}
+FilterInstance::~FilterInstance() {
+    delete[] mParam;
+    delete[] mParamFader;
+}
+result FilterInstance::initParams(int aNumParams) {
+    mNumParams = (unsigned int)aNumParams;
+    mParam = new float[aNumParams];
+    mParamFader = new Fader[aNumParams];
+    for (int i = 0; i < aNumParams; ++i) mParam[i] = 0.0f;
+    return 0;
+}
+void FilterInstance::updateParams(time) {}
+void FilterInstance::filter(float*, unsigned int, unsigned int, unsigned int, float, time) {}
+void FilterInstance::filterChannel(float*, unsigned int, float, time, unsigned int, unsigned int) {}
+float FilterInstance::getFilterParameter(unsigned int aId) { return mParam[aId]; }
+void FilterInstance::setFilterParameter(unsigned int aId, float aValue) { mParam[aId] = aValue; }
+void FilterInstance::fadeFilterParameter(unsigned int, float, time, time) {}
+void FilterInstance::oscillateFilterParameter(unsigned int, float, float, time, time) {}
+
+Filter::Filter() {}
+Filter::~Filter() {}
+int Filter::getParamCount() { return 0; }
+const char* Filter::getParamName(unsigned int) { return ""; }
+unsigned int Filter::getParamType(unsigned int) { return FLOAT_PARAM; }
+float Filter::getParamMax(unsigned int) { return 0; }
+float Filter::getParamMin(unsigned int) { return 0; }
+
+} // namespace SoLoud
+
+// ---- Test harness ---------------------------------------------------------
+
+static int g_failures = 0;
+static int g_assertions = 0;
+
+#define EXPECT(cond, fmt, ...) do { \
+    g_assertions++; \
+    if (!(cond)) { \
+        g_failures++; \
+        std::fprintf(stderr, "  FAIL [%s:%d] " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    } \
+} while (0)
+
+constexpr float SAMPLERATE = 48000.0f;
+
+// Build a fresh limiter with the given parameters (defaults match the
+// gphil-flutter app's audio_effects_snapshot.dart).
+struct LimiterRig {
+    Limiter parent;
+    LimiterInstance* inst;
+    float ceilingDb;
+    float ceilingLin;
+
+    explicit LimiterRig(
+        float wet = 1.0f,
+        float thresholdDb = -6.0f,
+        float ceilingDb = -1.0f,
+        float kneeDb = 6.0f,
+        float releaseMs = 50.0f,
+        float lookaheadMs = 1.0f
+    ) : parent((unsigned int)SAMPLERATE) {
+        parent.mWet = wet;
+        parent.mThreshold = thresholdDb;
+        parent.mOutputCeiling = ceilingDb;
+        parent.mKneeWidth = kneeDb;
+        parent.mReleaseTime = releaseMs;
+        parent.mAttackTime = lookaheadMs;
+        inst = static_cast<LimiterInstance*>(parent.createInstance());
+        this->ceilingDb = ceilingDb;
+        this->ceilingLin = std::pow(10.0f, ceilingDb / 20.0f);
+    }
+    ~LimiterRig() { delete inst; }
+
+    void run(float* buf, unsigned int frames, unsigned int channels) {
+        inst->filter(buf, frames, frames, channels, SAMPLERATE, 0.0);
+    }
+};
+
+// Allow a tiny float tolerance above the ceiling for cumulative FP error.
+constexpr float CEILING_EPS = 1e-5f;
+
+static float maxAbs(const float* buf, size_t n) {
+    float m = 0.f;
+    for (size_t i = 0; i < n; ++i) {
+        float a = std::fabs(buf[i]);
+        if (a > m) m = a;
+    }
+    return m;
+}
+
+// ---- Tests ----------------------------------------------------------------
+
+// 1. Ceiling MUST hold for a brutal one-sample full-scale impulse (the case
+//    the original SoLoud limiter leaks badly because of attack smoothing).
+static void testCeilingHonoredOnImpulse() {
+    std::printf("Test: ceiling honored on full-scale impulse\n");
+    LimiterRig rig;
+    constexpr unsigned int CHANNELS = 2;
+    constexpr unsigned int FRAMES = 4096;
+    std::vector<float> buf(FRAMES * CHANNELS, 0.0f);
+    // Full-scale spike on both channels at frame 100.
+    buf[100 * CHANNELS + 0] = 1.0f;
+    buf[100 * CHANNELS + 1] = 1.0f;
+
+    rig.run(buf.data(), FRAMES, CHANNELS);
+
+    float peak = maxAbs(buf.data(), buf.size());
+    EXPECT(peak <= rig.ceilingLin + CEILING_EPS,
+           "peak %.6f > ceiling %.6f", peak, rig.ceilingLin);
+    std::printf("    peak after limiter: %.6f (ceiling %.6f)\n", peak, rig.ceilingLin);
+}
+
+// 2. Sustained over-ceiling sine — output peak must stay at or below ceiling
+//    once the lookahead window has filled.
+static void testCeilingHonoredOnLoudSine() {
+    std::printf("Test: ceiling honored on +6 dB sustained sine\n");
+    LimiterRig rig;
+    constexpr unsigned int CHANNELS = 2;
+    constexpr unsigned int FRAMES = (unsigned int)(SAMPLERATE * 0.2f); // 200 ms
+    std::vector<float> buf(FRAMES * CHANNELS);
+    const float freq = 1000.0f;
+    const float amp = 2.0f; // +6 dB above 0 dBFS
+    for (unsigned int i = 0; i < FRAMES; ++i) {
+        float v = amp * std::sin(2.0f * (float)M_PI * freq * (float)i / SAMPLERATE);
+        buf[i * CHANNELS + 0] = v;
+        buf[i * CHANNELS + 1] = v;
+    }
+
+    rig.run(buf.data(), FRAMES, CHANNELS);
+
+    // Skip the lookahead priming region (first ~50 samples) when measuring.
+    const size_t startFrame = 200;
+    float peak = maxAbs(buf.data() + startFrame * CHANNELS,
+                        (FRAMES - startFrame) * CHANNELS);
+    EXPECT(peak <= rig.ceilingLin + CEILING_EPS,
+           "peak %.6f > ceiling %.6f", peak, rig.ceilingLin);
+    std::printf("    steady-state peak: %.6f (ceiling %.6f)\n", peak, rig.ceilingLin);
+}
+
+// 3. Quiet input below threshold should pass through at unity gain (after
+//    the lookahead delay). This catches accidental gain reduction on signals
+//    that shouldn't trigger any limiting.
+static void testQuietPassesThrough() {
+    std::printf("Test: -20 dB sine passes through at unity gain\n");
+    LimiterRig rig;
+    constexpr unsigned int CHANNELS = 2;
+    constexpr unsigned int FRAMES = (unsigned int)(SAMPLERATE * 0.05f); // 50 ms
+    std::vector<float> in(FRAMES * CHANNELS);
+    const float freq = 1000.0f;
+    const float amp = 0.1f; // -20 dB, well below -6 dB threshold knee
+    for (unsigned int i = 0; i < FRAMES; ++i) {
+        float v = amp * std::sin(2.0f * (float)M_PI * freq * (float)i / SAMPLERATE);
+        in[i * CHANNELS + 0] = v;
+        in[i * CHANNELS + 1] = v;
+    }
+    std::vector<float> buf = in;
+    rig.run(buf.data(), FRAMES, CHANNELS);
+
+    // Internal delay = ringSize - 1 = lookaheadSamples - 1 samples. After
+    // priming, output[i] should equal input[i - delay] sample-accurately.
+    const unsigned int lookahead = (unsigned int)(1.0f * 0.001f * SAMPLERATE + 0.5f);
+    const unsigned int delay = lookahead - 1;
+    float maxErr = 0.f;
+    for (unsigned int i = delay; i < FRAMES; ++i) {
+        for (unsigned int c = 0; c < CHANNELS; ++c) {
+            float err = std::fabs(buf[i * CHANNELS + c] - in[(i - delay) * CHANNELS + c]);
+            if (err > maxErr) maxErr = err;
+        }
+    }
+    EXPECT(maxErr < 1e-6f, "quiet signal altered, max sample error = %.3e", maxErr);
+    std::printf("    max sample error vs delayed input: %.3e\n", maxErr);
+}
+
+// 4. Stereo-linked gain — asymmetric L/R input should preserve the L:R
+//    amplitude ratio. The original limiter tracked L and R independently
+//    and broke the stereo image on transients.
+static void testStereoLinked() {
+    std::printf("Test: stereo image preserved under limiting\n");
+    LimiterRig rig;
+    constexpr unsigned int CHANNELS = 2;
+    constexpr unsigned int FRAMES = (unsigned int)(SAMPLERATE * 0.1f);
+    std::vector<float> buf(FRAMES * CHANNELS);
+    const float ampL = 1.5f; // over ceiling
+    const float ampR = 0.5f; // under ceiling
+    const float freq = 1000.0f;
+    for (unsigned int i = 0; i < FRAMES; ++i) {
+        float t = 2.0f * (float)M_PI * freq * (float)i / SAMPLERATE;
+        buf[i * CHANNELS + 0] = ampL * std::sin(t);
+        buf[i * CHANNELS + 1] = ampR * std::sin(t);
+    }
+    rig.run(buf.data(), FRAMES, CHANNELS);
+
+    // After settling, the two channels should still maintain their input
+    // amplitude ratio (3:1) within float tolerance.
+    const size_t startFrame = 200;
+    float peakL = 0.f, peakR = 0.f;
+    for (size_t i = startFrame; i < FRAMES; ++i) {
+        peakL = std::max(peakL, std::fabs(buf[i * CHANNELS + 0]));
+        peakR = std::max(peakR, std::fabs(buf[i * CHANNELS + 1]));
+    }
+    float ratio = peakL / std::max(peakR, 1e-9f);
+    float expectedRatio = ampL / ampR; // 3.0
+    float ratioErr = std::fabs(ratio - expectedRatio) / expectedRatio;
+    EXPECT(ratioErr < 0.02f,
+           "stereo ratio drifted: got %.4f, expected %.4f (%.2f%% error)",
+           ratio, expectedRatio, ratioErr * 100.f);
+    EXPECT(peakL <= rig.ceilingLin + CEILING_EPS,
+           "L peak %.6f > ceiling %.6f", peakL, rig.ceilingLin);
+    std::printf("    L peak %.4f, R peak %.4f, ratio %.4f (expected %.4f)\n",
+                peakL, peakR, ratio, expectedRatio);
+}
+
+// 5. Random over-ceiling noise across many parameter combinations — fuzz
+//    the limiter to verify the ceiling guarantee under arbitrary settings.
+static void testCeilingHonoredUnderFuzz() {
+    std::printf("Test: ceiling honored across fuzzed parameter combos\n");
+    constexpr unsigned int CHANNELS = 2;
+    constexpr unsigned int FRAMES = 8192;
+    std::srand(0xC0FFEE);
+
+    struct Params { float threshold; float ceiling; float knee; float release; float attack; };
+    Params combos[] = {
+        {-12.0f, -1.0f,  6.0f,  50.0f,   1.0f},
+        { -6.0f, -0.1f,  2.0f, 200.0f,   5.0f},
+        { -3.0f, -0.5f,  0.0f,   1.0f,   0.5f},
+        {-24.0f, -3.0f, 12.0f, 500.0f,  10.0f},
+        {-30.0f, -6.0f, 20.0f, 100.0f,   2.0f},
+        { -1.0f, -0.05f, 0.5f,  20.0f, 100.0f},
+    };
+
+    for (const auto& p : combos) {
+        LimiterRig rig(1.0f, p.threshold, p.ceiling, p.knee, p.release, p.attack);
+        std::vector<float> buf(FRAMES * CHANNELS);
+        for (unsigned int i = 0; i < FRAMES * CHANNELS; ++i) {
+            buf[i] = 4.0f * ((float)std::rand() / (float)RAND_MAX - 0.5f); // [-2, 2]
+        }
+        rig.run(buf.data(), FRAMES, CHANNELS);
+
+        // Skip the lookahead window for the peak measurement.
+        const unsigned int look = std::max(2u,
+            (unsigned int)(p.attack * 0.001f * SAMPLERATE + 0.5f));
+        float peak = maxAbs(buf.data() + look * CHANNELS,
+                            (FRAMES - look) * CHANNELS);
+        EXPECT(peak <= rig.ceilingLin + CEILING_EPS,
+               "thr=%.1f ceil=%.2f knee=%.1f rel=%.0f atk=%.1f -> peak %.6f > ceil %.6f",
+               p.threshold, p.ceiling, p.knee, p.release, p.attack, peak, rig.ceilingLin);
+    }
+    std::printf("    %zu combos passed\n", sizeof(combos)/sizeof(combos[0]));
+}
+
+// 6. Gain ramps DOWN before a peak instead of catching up after.
+//    Plant a single over-ceiling spike on a steady sub-ceiling tone and
+//    verify (a) the spike emerges at exactly the ceiling and (b) the
+//    samples emitted in the look-ahead window before it show clear
+//    pre-emptive gain reduction — i.e. the limiter started ramping the
+//    gain down BEFORE the peak arrived, not after.
+static void testLookaheadRampPrecedesPeak() {
+    std::printf("Test: gain ramps DOWN before the peak (true look-ahead)\n");
+    // threshold = ceiling so the spike output should land exactly on ceiling.
+    LimiterRig rig(1.0f, -1.0f, -1.0f, 0.0f, 50.0f, 2.0f /*2 ms look-ahead*/);
+    constexpr unsigned int CHANNELS = 1;
+    constexpr unsigned int FRAMES = 4096;
+    const unsigned int lookahead = (unsigned int)(2.0f * 0.001f * SAMPLERATE + 0.5f);
+    const unsigned int delay = lookahead - 1;
+    const unsigned int spikeIdx = 1000;
+    std::vector<float> buf(FRAMES * CHANNELS, 0.5f); // sustained tone (under ceiling)
+    buf[spikeIdx] = 4.0f;
+
+    rig.run(buf.data(), FRAMES, CHANNELS);
+
+    const unsigned int outSpikeIdx = spikeIdx + delay;
+    EXPECT(outSpikeIdx < FRAMES, "test setup error: out-of-range spike");
+
+    // The spike at the output should land at (or just below) ceiling.
+    float spikeOut = std::fabs(buf[outSpikeIdx]);
+    EXPECT(spikeOut <= rig.ceilingLin + CEILING_EPS,
+           "spike at output exceeded ceiling: %.6f > %.6f", spikeOut, rig.ceilingLin);
+    EXPECT(spikeOut > 0.85f * rig.ceilingLin,
+           "spike fell well below ceiling — limiter overreacting? %.6f vs %.6f",
+           spikeOut, rig.ceilingLin);
+
+    // Sample emitted RIGHT before the spike: tone (0.5) attenuated by the
+    // ramp. Required gain at the spike is ceiling/4 ≈ 0.223, so the sample
+    // one step before should be ~0.223 + (1-0.223)/lookahead, applied to 0.5.
+    float preSpike = std::fabs(buf[outSpikeIdx - 1]);
+    EXPECT(preSpike < 0.4f,
+           "no pre-emptive gain reduction before peak: pre-spike sample = %.4f", preSpike);
+
+    // And a sample well before the look-ahead window started attenuating:
+    // should still be at full 0.5 (the tone, unmodified).
+    const unsigned int farBefore = outSpikeIdx - lookahead - 200;
+    float farBeforeSample = std::fabs(buf[farBefore]);
+    EXPECT(farBeforeSample > 0.49f && farBeforeSample < 0.51f,
+           "tone was attenuated outside the lookahead window: %.4f", farBeforeSample);
+
+    std::printf("    far-before %.4f, pre-spike %.4f, spike %.4f (ceiling %.4f)\n",
+                farBeforeSample, preSpike, spikeOut, rig.ceilingLin);
+}
+
+// ---- main -----------------------------------------------------------------
+
+int main() {
+    std::printf("=== flutter_soloud limiter correctness tests ===\n\n");
+
+    testCeilingHonoredOnImpulse();
+    testCeilingHonoredOnLoudSine();
+    testQuietPassesThrough();
+    testStereoLinked();
+    testCeilingHonoredUnderFuzz();
+    testLookaheadRampPrecedesPeak();
+
+    std::printf("\n%d/%d assertions passed, %d failures\n",
+                g_assertions - g_failures, g_assertions, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/run_limiter_test.sh
+++ b/test/run_limiter_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build & run the standalone limiter correctness tests.
+# Run from the flutter_soloud repo root.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT="${TMPDIR:-/tmp}/limiter_test"
+
+c++ -std=c++17 -O2 -Wall \
+    -I src/soloud/include \
+    -o "$OUT" \
+    test/limiter_test.cpp src/filters/limiter.cpp
+
+"$OUT"


### PR DESCRIPTION
## Summary
- replace the limiter core with a true look-ahead brickwall/maximizer path
- interpret Threshold as input drive while Output Ceiling remains the final peak target
- stereo-link limiter gain reduction and use SoLoud planar buffer indexing
- fix compressor planar buffer indexing
- preserve the configured limiter ceiling through the final engine output path
- add standalone limiter correctness tests and refresh the example lockfile package version

## Why
The previous limiter smoothed attack after computing the required reduction, which could let transients leak above the configured ceiling. The filter buffers are planar, so interleaved indexing could also cross-feed channels and break stereo behavior.

## Validation
- `./test/run_limiter_test.sh`: 18/18 assertions passed
- `flutter analyze`: no issues found
- `git diff --check origin/main..HEAD`: no whitespace errors
