### PR TITLE
Fix audio crackling in `BufferingType.released` on Android

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "name": "Flutter debug",
             "type": "dart",
             "request": "launch",
-            "program": "lib/filters/parametric_eq.dart",
+            "program": "lib/main.dart",
             "flutterMode": "debug",
             // "env": {
             //     "NO_XIPH_LIBS": "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 4.0.7 (XX Xxx 2026)
 - add look-ahead brickwall limiter and fix planar DSP indexing #468. Thanks to @Kunstderfug
 - fix iOS CocoaPods wrapper double compile #467. Thanks to @DavidPluxia
+- Android fix: fix audio crackling using `BufferingType.released` on some Android devices #476
 
 #### 4.0.6 (17 May 2026)
 - Fix iOS SPM miniaudio duplicate symbols #465. Thanks to @coolswood

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     namespace = "com.example.flutter_soloud_example"
     compileSdk = flutter.compileSdkVersion
     // ndkVersion = flutter.ndkVersion
-    ndkVersion = "27.0.12077973"
+    // ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -4,3 +4,7 @@ android.enableJetifier=true
 
 # uncomment to disable Xiph libraries (Opus, Ogg, Vorbis, Flac) support
 # NO_XIPH_LIBS=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Flutter (1.0.0)
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+
+PODFILE CHECKSUM: a98e409c76f5d085e644fff17d5b0f8ddf9350d9
+
+COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		98F0A7DFF4AE43437F171C1D /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BE23ECA1E6D264CEDAD411A /* Pods_Runner.framework */; };
+		E2B63B62788536E94B4DA289 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5932D23076234F6469522122 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,15 +45,23 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		277DCDC10BBC87D6782551B2 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		5932D23076234F6469522122 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C0DD040AD93EEF69F59D973 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		6114DAB62A58BE8900160B22 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		6114DAB82A58BE9200160B22 /* AVFAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFAudio.framework; path = System/Library/Frameworks/AVFAudio.framework; sourceTree = SDKROOT; };
 		6114DABA2A58BE9D00160B22 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		61827B802A58C51C00C5CD25 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		62871C70906CD1B4026E7DEF /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		698CF0BC5D063BE2F1A3E51C /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		6BE23ECA1E6D264CEDAD411A /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* flutter_soloud */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = flutter_soloud; path = ../../ios/flutter_soloud; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
@@ -61,6 +71,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AC3F0D5A2529D28D5CEDF19C /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		AF8BABF39A707025301B7933 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +81,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				98F0A7DFF4AE43437F171C1D /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,6 +89,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E2B63B62788536E94B4DA289 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,6 +111,8 @@
 				6114DABA2A58BE9D00160B22 /* AudioToolbox.framework */,
 				6114DAB82A58BE9200160B22 /* AVFAudio.framework */,
 				6114DAB62A58BE8900160B22 /* AVFoundation.framework */,
+				6BE23ECA1E6D264CEDAD411A /* Pods_Runner.framework */,
+				5932D23076234F6469522122 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -104,6 +120,8 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* flutter_soloud */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
@@ -152,6 +170,12 @@
 		C43026EC0597D588B23C294C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				277DCDC10BBC87D6782551B2 /* Pods-Runner.debug.xcconfig */,
+				AF8BABF39A707025301B7933 /* Pods-Runner.release.xcconfig */,
+				5C0DD040AD93EEF69F59D973 /* Pods-Runner.profile.xcconfig */,
+				698CF0BC5D063BE2F1A3E51C /* Pods-RunnerTests.debug.xcconfig */,
+				AC3F0D5A2529D28D5CEDF19C /* Pods-RunnerTests.release.xcconfig */,
+				62871C70906CD1B4026E7DEF /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -163,6 +187,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				7A8278522A7C930B05A2B488 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				ADBFEEB948A609045252668A /* Frameworks */,
@@ -181,6 +206,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				CA940C9E964E65E5023E46A7 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -280,6 +306,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin\n";
 		};
+		7A8278522A7C930B05A2B488 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -294,6 +342,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		CA940C9E964E65E5023E46A7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -422,6 +492,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 698CF0BC5D063BE2F1A3E51C /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -439,6 +510,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AC3F0D5A2529D28D5CEDF19C /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -454,6 +526,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 62871C70906CD1B4026E7DEF /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/src/audiobuffer/audiobuffer.cpp
+++ b/src/audiobuffer/audiobuffer.cpp
@@ -34,13 +34,13 @@ BufferStreamInstance::~BufferStreamInstance() {}
 unsigned int BufferStreamInstance::getAudio(float *aBuffer,
                                             unsigned int aSamplesToRead,
                                             unsigned int aBufferSize) {
-  std::lock_guard<std::mutex> lock(buffer_lock_mutex);
-
   // Check if parent is still valid before accessing it
   if (mParent == nullptr || !mParent->isValid()) {
     memset(aBuffer, 0, sizeof(float) * aSamplesToRead * mChannels);
     return 0;
   }
+
+  std::lock_guard<std::recursive_mutex> lock(mParent->mBuffer.bufferMutex);
 
   // When using BufferType::AUTO, samplerate and channels are got from the
   // stream. Hence we need to update them regardless of how are set by
@@ -64,7 +64,7 @@ unsigned int BufferStreamInstance::getAudio(float *aBuffer,
   }
 
   unsigned int bufferSize = static_cast<unsigned int>(mParent->mBuffer.getFloatsBufferSize());
-  float *buffer = reinterpret_cast<float *>(mParent->mBuffer.buffer.data());
+  float *buffer = reinterpret_cast<float *>(mParent->mBuffer.buffer.data() + mParent->mBuffer.getReadOffset());
   int samplesToRead = aSamplesToRead;
   if (mOffset + (unsigned int)samplesToRead * mChannels > bufferSize) {
     samplesToRead = (bufferSize - mOffset) / mChannels;

--- a/src/audiobuffer/buffer.h
+++ b/src/audiobuffer/buffer.h
@@ -22,11 +22,15 @@ public:
 
 private:
     size_t maxBytes; // Maximum capacity in bytes
-    std::mutex bufferMutex; // Add mutex for thread safety
+    size_t readOffset; // Byte offset to active data (used in RELEASED mode)
 
 public:
+    std::recursive_mutex bufferMutex; // Add mutex for thread safety
+
+    size_t getReadOffset() const { return readOffset; }
+
     // Constructor that accepts the maxBytes parameter
-    Buffer() : bufferingType(BufferingType::PRESERVED), maxBytes(0) {}
+    Buffer() : bufferingType(BufferingType::PRESERVED), maxBytes(0), readOffset(0) {}
 
     ~Buffer()
     {
@@ -98,7 +102,18 @@ public:
     // Overload for float data, directly adding its bytes to the buffer.
     // Return the number of floats written.
     size_t addData(const float* data, size_t numSamples, bool *allDataAdded) {
-        std::lock_guard<std::mutex> lock(bufferMutex); // Lock during modification
+        std::lock_guard<std::recursive_mutex> lock(bufferMutex); // Lock during modification
+
+        // Compact buffer when more than half has been consumed
+        if (readOffset > 0 && (buffer.size() - readOffset) < readOffset) {
+            size_t remaining = buffer.size() - readOffset;
+            if (remaining > 0) {
+                memmove(buffer.data(), buffer.data() + readOffset, remaining);
+            }
+            buffer.resize(remaining);
+            readOffset = 0;
+        }
+
         uint64_t bytesNeeded = numSamples * sizeof(float);
         int64_t newNumSamples = numSamples;
         if (buffer.size() + bytesNeeded > maxBytes)
@@ -116,31 +131,35 @@ public:
 
     // Remove data from the start of the buffer
     size_t removeData(size_t bytesToRemove) {
-        std::lock_guard<std::mutex> lock(bufferMutex); // Lock during modification
+        std::lock_guard<std::recursive_mutex> lock(bufferMutex); // Lock during modification
         size_t samplesRemoved = 0;
         if (bufferingType == BufferingType::RELEASED && bytesToRemove > 0) {
             samplesRemoved = bytesToRemove / sizeof(float);
-            if (bytesToRemove >= buffer.size()) {
+            size_t activeSize = buffer.size() > readOffset ? buffer.size() - readOffset : 0;
+            if (bytesToRemove >= activeSize) {
                 buffer.clear();
+                readOffset = 0;
             } else {
-                buffer.erase(buffer.begin(), buffer.begin() + bytesToRemove);
+                readOffset += bytesToRemove;
             }
         }
         return samplesRemoved;
     }
 
-    // Function to get the current size of the buffer in bytes
+    // Function to get the current size of the buffer in floats
     size_t getFloatsBufferSize()
     {
-        std::lock_guard<std::mutex> lock(bufferMutex); // Lock during read
-        return buffer.size() / sizeof(float);
+        std::lock_guard<std::recursive_mutex> lock(bufferMutex); // Lock during read
+        if (buffer.size() <= readOffset) return 0;
+        return (buffer.size() - readOffset) / sizeof(float);
     }
 
     // Clear the buffer
     void clear()
     {
-        std::lock_guard<std::mutex> lock(bufferMutex); // Lock during modification
+        std::lock_guard<std::recursive_mutex> lock(bufferMutex); // Lock during modification
         buffer.clear();
+        readOffset = 0;
     }
 };
 


### PR DESCRIPTION
## Description

Replaced 'std::vector::erase' with a lazy read-offset in 'Buffer::removeData()', eliminating an O(n) memmove inside the real-time audio callback that caused buffer underruns and crackling on Android devices.

Fixes #469

## Type of Change

- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)