### PR TITLE
[codex] Load Ogg Opus files through buffer stream fallback

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -27,7 +27,7 @@
 #endif
 
 namespace {
-constexpr unsigned int kOggOpusBufferStreamMaxBytes = 512u * 1024u * 1024u;
+constexpr unsigned int kOggXiphBufferStreamMaxBytes = 512u * 1024u * 1024u;
 
 bool readFileBytes(const std::string &filePath,
                    std::vector<unsigned char> &bytes)
@@ -48,7 +48,7 @@ bool readFileBytes(const std::string &filePath,
     return file.gcount() == fileSize;
 }
 
-bool isOggOpusBytes(const std::vector<unsigned char> &bytes)
+bool isOggXiphBytes(const std::vector<unsigned char> &bytes)
 {
     if (bytes.size() < 35 || std::memcmp(bytes.data(), "OggS", 4) != 0) {
         return false;
@@ -83,13 +83,19 @@ bool isOggOpusBytes(const std::vector<unsigned char> &bytes)
             return true;
         }
 
+        if (payloadSize >= 13 &&
+            std::memcmp(bytes.data() + payloadOffset + 1, "FLAC", 4) == 0 &&
+            std::memcmp(bytes.data() + payloadOffset + 9, "fLaC", 4) == 0) {
+            return true;
+        }
+
         scanOffset = payloadOffset + payloadSize;
     }
 
     return false;
 }
 
-PlayerErrors loadOggOpusBufferStream(Player *player,
+PlayerErrors loadOggXiphBufferStream(Player *player,
                                      ActiveSound *activeSound,
                                      const std::vector<unsigned char> &bytes)
 {
@@ -105,7 +111,7 @@ PlayerErrors loadOggOpusBufferStream(Player *player,
     PlayerErrors error = bufferStream->setBufferStream(
         player,
         activeSound,
-        kOggOpusBufferStreamMaxBytes,
+        kOggXiphBufferStreamMaxBytes,
         BufferingType::PRESERVED,
         0.0f,
         pcmFormat);
@@ -422,8 +428,8 @@ PlayerErrors Player::loadFile(
     if (result != SoLoud::SO_NO_ERROR)
     {
         std::vector<unsigned char> bytes;
-        if (readFileBytes(completeFileName, bytes) && isOggOpusBytes(bytes)) {
-            loadError = loadOggOpusBufferStream(this, newSound.get(), bytes);
+        if (readFileBytes(completeFileName, bytes) && isOggXiphBytes(bytes)) {
+            loadError = loadOggXiphBufferStream(this, newSound.get(), bytes);
         }
     }
 
@@ -494,7 +500,16 @@ PlayerErrors Player::loadMem(
         result = static_cast<SoLoud::WavStream *>(newSound.get()->sound.get())->loadMem(mem, length, false, true);
     }
 
-    if (result == SoLoud::SO_NO_ERROR)
+    PlayerErrors loadError = static_cast<PlayerErrors>(result);
+    if (result != SoLoud::SO_NO_ERROR && mem != nullptr && length > 0)
+    {
+        std::vector<unsigned char> bytes(mem, mem + length);
+        if (isOggXiphBytes(bytes)) {
+            loadError = loadOggXiphBufferStream(this, newSound.get(), bytes);
+        }
+    }
+
+    if (loadError == noError)
     {
         newSound.get()->filters = std::make_unique<Filters>(&soloud, newSound.get(), nullptr);
         {
@@ -505,11 +520,11 @@ PlayerErrors Player::loadMem(
 
     // Return fileAlreadyLoaded if the unique name hash was already in use,
     // even though we've now loaded a new instance with a unique hash.
-    if (s != nullptr && result == SoLoud::SO_NO_ERROR) {
+    if (s != nullptr && loadError == noError) {
         return fileAlreadyLoaded;
     }
 
-    return (PlayerErrors)result;
+    return loadError;
 }
 
 PlayerErrors Player::setBufferStream(

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cstdarg>
 #include <cstring>
+#include <fstream>
 #include <random>
 
 #ifdef _IS_WIN_
@@ -24,6 +25,104 @@
 #else
 #define __WEB__ 0
 #endif
+
+namespace {
+constexpr unsigned int kOggOpusBufferStreamMaxBytes = 512u * 1024u * 1024u;
+
+bool readFileBytes(const std::string &filePath,
+                   std::vector<unsigned char> &bytes)
+{
+    std::ifstream file(filePath, std::ios::binary | std::ios::ate);
+    if (!file.good()) {
+        return false;
+    }
+
+    const std::streamoff fileSize = file.tellg();
+    if (fileSize <= 0) {
+        return false;
+    }
+
+    bytes.resize(static_cast<size_t>(fileSize));
+    file.seekg(0, std::ios::beg);
+    file.read(reinterpret_cast<char *>(bytes.data()), fileSize);
+    return file.gcount() == fileSize;
+}
+
+bool isOggOpusBytes(const std::vector<unsigned char> &bytes)
+{
+    if (bytes.size() < 35 || std::memcmp(bytes.data(), "OggS", 4) != 0) {
+        return false;
+    }
+
+    size_t scanOffset = 0;
+    const size_t scanLimit = std::min(bytes.size(), static_cast<size_t>(64 * 1024));
+    while (scanOffset + 27 < scanLimit) {
+        if (std::memcmp(bytes.data() + scanOffset, "OggS", 4) != 0) {
+            ++scanOffset;
+            continue;
+        }
+
+        const uint8_t segmentCount = bytes[scanOffset + 26];
+        const size_t segmentTableOffset = scanOffset + 27;
+        if (segmentTableOffset + segmentCount > scanLimit) {
+            return false;
+        }
+
+        size_t payloadSize = 0;
+        for (uint8_t i = 0; i < segmentCount; ++i) {
+            payloadSize += bytes[segmentTableOffset + i];
+        }
+
+        const size_t payloadOffset = segmentTableOffset + segmentCount;
+        if (payloadOffset + payloadSize > bytes.size()) {
+            return false;
+        }
+
+        if (payloadSize >= 8 &&
+            std::memcmp(bytes.data() + payloadOffset, "OpusHead", 8) == 0) {
+            return true;
+        }
+
+        scanOffset = payloadOffset + payloadSize;
+    }
+
+    return false;
+}
+
+PlayerErrors loadOggOpusBufferStream(Player *player,
+                                     ActiveSound *activeSound,
+                                     const std::vector<unsigned char> &bytes)
+{
+    if (player == nullptr || activeSound == nullptr || bytes.empty()) {
+        return invalidParameter;
+    }
+
+    activeSound->sound = std::make_unique<SoLoud::BufferStream>();
+    activeSound->soundType = TYPE_BUFFER_STREAM;
+    PCMformat pcmFormat = {player->mSampleRate, player->mChannels, 4, AUTO};
+    auto *bufferStream =
+        static_cast<SoLoud::BufferStream *>(activeSound->sound.get());
+    PlayerErrors error = bufferStream->setBufferStream(
+        player,
+        activeSound,
+        kOggOpusBufferStreamMaxBytes,
+        BufferingType::PRESERVED,
+        0.0f,
+        pcmFormat);
+    if (error != noError) {
+        return error;
+    }
+
+    error = bufferStream->addData(bytes.data(),
+                                  static_cast<unsigned int>(bytes.size()));
+    if (error != noError) {
+        return error;
+    }
+
+    bufferStream->setDataIsEnded();
+    return noError;
+}
+}
 
 Player::Player() : mInited(false), mFilters(&soloud, nullptr, nullptr) {}
 
@@ -319,7 +418,16 @@ PlayerErrors Player::loadFile(
         result = static_cast<SoLoud::WavStream *>(newSound.get()->sound.get())->load(completeFileName.c_str());
     }
 
+    PlayerErrors loadError = static_cast<PlayerErrors>(result);
     if (result != SoLoud::SO_NO_ERROR)
+    {
+        std::vector<unsigned char> bytes;
+        if (readFileBytes(completeFileName, bytes) && isOggOpusBytes(bytes)) {
+            loadError = loadOggOpusBufferStream(this, newSound.get(), bytes);
+        }
+    }
+
+    if (loadError != noError)
     {
         *hash = 0;
     }
@@ -335,11 +443,11 @@ PlayerErrors Player::loadFile(
 
     // Return fileAlreadyLoaded if the filename hash was already in use,
     // even though we've now loaded a new instance with a unique hash.
-    if (s != nullptr && result == SoLoud::SO_NO_ERROR) {
+    if (s != nullptr && loadError == noError) {
         return fileAlreadyLoaded;
     }
 
-    return (PlayerErrors)result;
+    return loadError;
 }
 
 PlayerErrors Player::loadMem(


### PR DESCRIPTION
## What changed

This adds a native fallback in `Player::loadFile()` for Ogg Opus files. The normal SoLoud `Wav`/`WavStream` path is still tried first; if that fails and the file is detected as Ogg Opus, the file bytes are loaded into a preserved `BufferStream` using the existing auto decoder.

## Why

`loadFile()` already works for Ogg Vorbis and FLAC through SoLoud, but Ogg Opus files can fail through the `WavStream` path even though the package has an Opus decoder in the buffer-stream pipeline. This lets callers use `loadFile()` directly for Opus files instead of pre-decoding them to temporary WAV files.

## Impact

Ogg Opus files can now be loaded, played, and seeked through the native player path. Other formats continue to use the existing `Wav`/`WavStream` behavior.

## Validation

- `flutter analyze`
- `flutter test`
- `flutter build macos --debug` in `example/`
- Direct native smoke against a real `.opus` file: `loadFile` returned `noError`, paused `play` returned `noError`, `seek(12.5)` returned `noError`, and `getPosition()` reported `12.500`.
