### PR TITLE
Fix released buffer stream size reporting

### DIFF
--- a/src/audiobuffer/buffer.h
+++ b/src/audiobuffer/buffer.h
@@ -29,6 +29,11 @@ public:
 
     size_t getReadOffset() const { return readOffset; }
 
+    size_t getActiveSizeInBytes() const {
+        if (buffer.size() <= readOffset) return 0;
+        return buffer.size() - readOffset;
+    }
+
     // Constructor that accepts the maxBytes parameter
     Buffer() : bufferingType(BufferingType::PRESERVED), maxBytes(0), readOffset(0) {}
 
@@ -150,8 +155,7 @@ public:
     size_t getFloatsBufferSize()
     {
         std::lock_guard<std::recursive_mutex> lock(bufferMutex); // Lock during read
-        if (buffer.size() <= readOffset) return 0;
-        return (buffer.size() - readOffset) / sizeof(float);
+        return getActiveSizeInBytes() / sizeof(float);
     }
 
     // Clear the buffer

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -519,9 +519,11 @@ PlayerErrors Player::getBufferSize(unsigned int hash, unsigned int *sizeInBytes)
     if (s == nullptr || s->soundType != SoundType::TYPE_BUFFER_STREAM)
         return PlayerErrors::soundHashNotFound;
 
+    auto *bufferStream = static_cast<SoLoud::BufferStream *>(s->sound.get());
+    std::lock_guard<std::recursive_mutex> lock(bufferStream->mBuffer.bufferMutex);
     *sizeInBytes = static_cast<unsigned int>(
-        static_cast<SoLoud::BufferStream *>(s->sound.get())->mBuffer.buffer.size() +
-        static_cast<SoLoud::BufferStream *>(s->sound.get())->buffer.size());
+        bufferStream->mBuffer.getActiveSizeInBytes() +
+        bufferStream->buffer.size());
     return PlayerErrors::noError;
 }
 


### PR DESCRIPTION
## What changed

Fix `getBufferSize()` for `BufferingType.released` buffer streams so it reports only unread active bytes, not the full backing vector including bytes that have already been consumed by playback.

## Why

Released buffer streams keep a `readOffset` and avoid erasing consumed bytes immediately. `getFloatsBufferSize()` already subtracts that offset, but `Player::getBufferSize()` still returned `mBuffer.buffer.size()`, which includes consumed bytes. A feeder that uses `getBufferSize()` for backpressure can therefore believe enough playable audio is buffered while the readable buffer is actually low or empty, causing underruns/glitches.

## Details

- Added `Buffer::getActiveSizeInBytes()` to expose the unread byte count behind the current read offset.
- Reused that helper from `getFloatsBufferSize()`.
- Updated `Player::getBufferSize()` to report active unread bytes plus any pending encoded staging buffer bytes.
- Locked `mBuffer.bufferMutex` while reading the active buffer size for consistency with the buffer helpers.

## Validation

- `flutter analyze`
- Verified in a downstream app using a realtime `BufferingType.released` PCM stream feeder: playback glitches caused by underfeeding disappeared after this fix.
