### PR TITLE
add `lowLatency` init option to allow recordable Android output

### DIFF
--- a/lib/src/bindings/bindings_player.dart
+++ b/lib/src/bindings/bindings_player.dart
@@ -85,6 +85,7 @@ abstract class FlutterSoLoud {
     int sampleRate,
     int bufferSize,
     Channels channels,
+    bool lowLatency,
   );
 
   /// Change the playback device.

--- a/lib/src/bindings/bindings_player.dart
+++ b/lib/src/bindings/bindings_player.dart
@@ -88,6 +88,14 @@ abstract class FlutterSoLoud {
     bool lowLatency,
   );
 
+  /// Android only: when [managed] is true (default) SoLoud tags the AAudio
+  /// stream as media/music; when false it leaves usage/contentType unset so the
+  /// app can manage AudioAttributes externally (e.g. via audio_session). Only
+  /// affects the native backends with low-latency disabled; call before
+  /// [initEngine]. No effect on web.
+  @mustBeOverridden
+  void setAndroidAudioAttributes(bool managed);
+
   /// Change the playback device.
   ///
   /// [deviceId] the device ID. -1 for default OS output device.

--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -265,8 +265,15 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
     int sampleRate,
     int bufferSize,
     Channels channels,
+    bool lowLatency,
   ) {
-    final ret = _initEngine(deviceId, sampleRate, bufferSize, channels.count);
+    final ret = _initEngine(
+      deviceId,
+      sampleRate,
+      bufferSize,
+      channels.count,
+      lowLatency ? 1 : 0,
+    );
     return PlayerErrors.values[ret];
   }
 
@@ -278,11 +285,12 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
             ffi.UnsignedInt,
             ffi.UnsignedInt,
             ffi.UnsignedInt,
+            ffi.UnsignedInt,
           )
         >
       >('initEngine');
   late final _initEngine = _initEnginePtr
-      .asFunction<int Function(int, int, int, int)>();
+      .asFunction<int Function(int, int, int, int, int)>();
 
   @override
   PlayerErrors changeDevice(int deviceId) {

--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -293,6 +293,18 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
       .asFunction<int Function(int, int, int, int, int)>();
 
   @override
+  void setAndroidAudioAttributes(bool managed) {
+    _setAndroidAudioAttributes(managed ? 1 : 0);
+  }
+
+  late final _setAndroidAudioAttributesPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.UnsignedInt)>>(
+        'setAndroidAudioAttributes',
+      );
+  late final _setAndroidAudioAttributes =
+      _setAndroidAudioAttributesPtr.asFunction<void Function(int)>();
+
+  @override
   PlayerErrors changeDevice(int deviceId) {
     final ret = _changeDevice(deviceId);
     return PlayerErrors.values[ret];

--- a/lib/src/bindings/bindings_player_web.dart
+++ b/lib/src/bindings/bindings_player_web.dart
@@ -136,6 +136,11 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
   }
 
   @override
+  void setAndroidAudioAttributes(bool managed) {
+    // No-op on web: AAudio stream attributes are Android-only.
+  }
+
+  @override
   PlayerErrors changeDevice(int deviceId) {
     final ret = wasmChangeDevice(deviceId);
     return PlayerErrors.values[ret];

--- a/lib/src/bindings/bindings_player_web.dart
+++ b/lib/src/bindings/bindings_player_web.dart
@@ -121,12 +121,16 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     int sampleRate,
     int bufferSize,
     Channels channels,
+    bool lowLatency,
   ) {
+    // [lowLatency] only affects the native miniaudio backends (it selects the
+    // AAudio/CoreAudio performance profile); the Web Audio backend ignores it.
     final ret = wasmInitEngine(
       deviceId,
       sampleRate,
       bufferSize,
       channels.count,
+      lowLatency ? 1 : 0,
     );
     return PlayerErrors.values[ret];
   }

--- a/lib/src/bindings/js_extension.dart
+++ b/lib/src/bindings/js_extension.dart
@@ -94,6 +94,7 @@ external int wasmInitEngine(
   int sampleRate,
   int bufferSize,
   int channels,
+  int lowLatency,
 );
 
 @JS('Module_soloud._changeDevice')

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -133,6 +133,19 @@ Float32List _readSamplesFromMem(Map<String, dynamic> args) {
   );
 }
 
+/// How SoLoud sets the Android (AAudio) stream's `AudioAttributes` when
+/// low-latency is disabled. See [SoLoud.init]'s `androidAudioAttributes`.
+enum AndroidAudioAttributes {
+  /// Tag the stream as `usage = media` / `contentType = music` (default).
+  /// Sensible for a media app and capturable by system screen recorders.
+  mediaMusic,
+
+  /// Leave usage/contentType unset so the app can manage `AudioAttributes`
+  /// externally (e.g. via the `audio_session` plugin) without SoLoud
+  /// overriding them. The screen-record capture policy is still applied.
+  unmanaged,
+}
+
 /// The main class to call all the audio methods that play sounds.
 ///
 /// This class has a singleton [instance] which represents the (also singleton)
@@ -347,6 +360,18 @@ interface class SoLoud {
   /// instead: the output becomes capturable by screen recording and gains
   /// callback headroom for DSP, at the cost of higher output latency. Only the
   /// native (miniaudio) backends honor this; the Web backend ignores it.
+  ///
+  /// [androidAudioAttributes] (Android, native, `lowLatency: false` only)
+  /// controls the AAudio stream's `AudioAttributes`. The default
+  /// [AndroidAudioAttributes.mediaMusic] tags the stream as `usage = media` /
+  /// `contentType = music` — sensible for a media app and capturable by screen
+  /// recorders. Pass [AndroidAudioAttributes.unmanaged] if you set the app's
+  /// attributes/focus yourself (e.g. via the `audio_session` plugin): SoLoud
+  /// then leaves usage/contentType unset so they don't fight your
+  /// configuration. Either way the choice is preserved across output-device
+  /// changes. (Note these are the *stream's* attributes; `audio_session`
+  /// controls the *focus request* — for correct ducking they should match.)
+  /// Ignored when `lowLatency` is true, on non-Android platforms, and on web.
   Future<void> init({
     PlaybackDevice? device,
     bool automaticCleanup = false,
@@ -354,6 +379,8 @@ interface class SoLoud {
     int bufferSize = 2048,
     Channels channels = Channels.stereo,
     bool lowLatency = true,
+    AndroidAudioAttributes androidAudioAttributes =
+        AndroidAudioAttributes.mediaMusic,
   }) async {
     final nativeIsInitialized = _controller.soLoudFFI.isInited();
     _log.finest('init() called');
@@ -395,6 +422,12 @@ interface class SoLoud {
       _controller.soLoudFFI.clearDartCallbackRegistrations();
       deinit();
     }
+
+    // Must be set before the engine opens the device so the backend picks it
+    // up at stream creation (and re-applies it on device changes).
+    _controller.soLoudFFI.setAndroidAudioAttributes(
+      androidAudioAttributes == AndroidAudioAttributes.mediaMusic,
+    );
 
     final error = _controller.soLoudFFI.initEngine(
       device?.id ?? -1,

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -338,12 +338,22 @@ interface class SoLoud {
   /// The default value is 2048.
   ///
   /// [channels] mono, stereo, quad, 5.1, 7.1.
+  ///
+  /// [lowLatency] selects the audio backend's performance profile and defaults
+  /// to `true` (the historical behavior). On Android the low-latency profile
+  /// uses AAudio's MMAP path, which cannot be captured by system screen
+  /// recorders and leaves little CPU headroom for heavy filters (e.g. the FFT
+  /// pitch shift). Pass `false` to use the conservative (legacy mixer) profile
+  /// instead: the output becomes capturable by screen recording and gains
+  /// callback headroom for DSP, at the cost of higher output latency. Only the
+  /// native (miniaudio) backends honor this; the Web backend ignores it.
   Future<void> init({
     PlaybackDevice? device,
     bool automaticCleanup = false,
     int sampleRate = 44100,
     int bufferSize = 2048,
     Channels channels = Channels.stereo,
+    bool lowLatency = true,
   }) async {
     final nativeIsInitialized = _controller.soLoudFFI.isInited();
     _log.finest('init() called');
@@ -391,6 +401,7 @@ interface class SoLoud {
       sampleRate,
       bufferSize,
       channels,
+      lowLatency,
     );
     _logPlayerError(error, from: 'initialize() result');
     if (error == PlayerErrors.noError) {

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -248,6 +248,15 @@ FFI_PLUGIN_EXPORT enum PlayerErrors initEngine(int deviceID,
         return PlayerErrors::noError;
     }
 
+/// Android only: choose whether SoLoud tags the AAudio stream's
+/// usage/contentType (media/music) or leaves them unset so the app can manage
+/// AudioAttributes externally (e.g. via the audio_session plugin). Only takes
+/// effect with low-latency disabled. Call before initEngine(). No effect on
+/// other backends. [managed] != 0 → media/music (default); 0 → leave unset.
+FFI_PLUGIN_EXPORT void setAndroidAudioAttributes(unsigned int managed) {
+  SoLoud::miniaudio_setAndroidAudioAttributes(managed != 0);
+}
+
 /// Change the playback device.
 ///
 /// [deviceID] the device ID. -1 for default OS output device.

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -221,7 +221,8 @@ FFI_PLUGIN_EXPORT bool areXiphLibsAvailable() {
 FFI_PLUGIN_EXPORT enum PlayerErrors initEngine(int deviceID,
                                                unsigned int sampleRate,
                                                unsigned int bufferSize,
-                                               unsigned int channels) {
+                                               unsigned int channels,
+                                               unsigned int lowLatency) {
   std::lock_guard<std::mutex> guard(init_deinit_mutex);
   std::lock_guard<std::mutex> guard_load(loadMutex);
 
@@ -230,7 +231,8 @@ FFI_PLUGIN_EXPORT enum PlayerErrors initEngine(int deviceID,
 
   player.get()->setStateChangedCallback(stateChangedCallback);
   PlayerErrors res = (PlayerErrors)player.get()->init(sampleRate, bufferSize,
-                                                      channels, deviceID);
+                                                      channels, deviceID,
+                                                      lowLatency != 0);
   if (res != noError)
     return res;
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -194,10 +194,17 @@ void Player::setStateChangedCallback(void (*stateChangedCallback)(unsigned int))
     soloud.setStateChangedCallback(stateChangedCallback);
 }
 
-PlayerErrors Player::init(unsigned int sampleRate, unsigned int bufferSize, unsigned int channels, int deviceID)
+// Defined in the miniaudio backend (soloud_miniaudio.cpp). Forward-declared
+// here so we don't need to pull in the backend-internal header.
+namespace SoLoud { void miniaudio_setLowLatency(bool aLowLatency); }
+
+PlayerErrors Player::init(unsigned int sampleRate, unsigned int bufferSize, unsigned int channels, int deviceID, bool lowLatency)
 {
     if (mInited)
         return playerAlreadyInited;
+
+    // Choose the device performance profile before SoLoud opens the backend.
+    SoLoud::miniaudio_setLowLatency(lowLatency);
 
     void *playbackInfos_id = nullptr;
     if (deviceID != -1)

--- a/src/player.h
+++ b/src/player.h
@@ -44,7 +44,8 @@ public:
   /// @param deviceID the device ID. -1 for default OS output device.
   /// @return Returns [PlayerErrors.SO_NO_ERROR] if success.
   PlayerErrors init(unsigned int sampleRate, unsigned int bufferSize,
-                    unsigned int channels, int deviceID = -1);
+                    unsigned int channels, int deviceID = -1,
+                    bool lowLatency = true);
 
   /// @brief Change the playback device.
   /// @param deviceID the device ID. -1 for default OS output device.

--- a/src/soloud/include/soloud_internal.h
+++ b/src/soloud/include/soloud_internal.h
@@ -80,6 +80,11 @@ namespace SoLoud
 	// When false, opens the device on the conservative (legacy mixer) profile
 	// instead of the default low-latency/MMAP path. Must be called before init.
 	void miniaudio_setLowLatency(bool aLowLatency);
+	// Android only: when true (default), tags the AAudio stream usage/contentType
+	// as media/music; when false, leaves them unset so the app can manage
+	// AudioAttributes externally (e.g. via audio_session). Must be called before
+	// init. No-op effect on non-Android backends.
+	void miniaudio_setAndroidAudioAttributes(bool aManaged);
 
 	// nosound back-end initialization call
 	result nosound_init(SoLoud::Soloud* aSoloud, unsigned int aFlags = Soloud::CLIP_ROUNDOFF, unsigned int aSamplerate = 44100, unsigned int aBuffer = 2048, unsigned int aChannels = 2);

--- a/src/soloud/include/soloud_internal.h
+++ b/src/soloud/include/soloud_internal.h
@@ -77,6 +77,9 @@ namespace SoLoud
 	// MiniAudio back-end initialization call
 	result miniaudio_init(SoLoud::Soloud* aSoloud, unsigned int aFlags = Soloud::CLIP_ROUNDOFF, unsigned int aSamplerate = 44100, unsigned int aBuffer = 2048, unsigned int aChannels = 2, void *pPlaybackInfos_id = nullptr);
 	result miniaudio_changeDevice_impl(void *pPlaybackInfos_id);
+	// When false, opens the device on the conservative (legacy mixer) profile
+	// instead of the default low-latency/MMAP path. Must be called before init.
+	void miniaudio_setLowLatency(bool aLowLatency);
 
 	// nosound back-end initialization call
 	result nosound_init(SoLoud::Soloud* aSoloud, unsigned int aFlags = Soloud::CLIP_ROUNDOFF, unsigned int aSamplerate = 44100, unsigned int aBuffer = 2048, unsigned int aChannels = 2);

--- a/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
+++ b/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
@@ -45,6 +45,25 @@ namespace SoLoud
     {
         gMiniaudioLowLatency = aLowLatency;
     }
+
+    // Android (AAudio) stream attributes applied when low-latency is disabled.
+    // Default to media/music (sensible for a media app, and capturable). When
+    // [aManaged] is false the app wants to own AudioAttributes externally (e.g.
+    // via the audio_session plugin), so we leave usage/contentType unset
+    // (`_default`) and let AAudio pick its defaults. Stored in globals so the
+    // SAME choice is re-applied on device changes (see both call sites) rather
+    // than reverting. Defined outside the WITH_MINIAUDIO guard so the setter
+    // symbol always exists for the C bindings to call.
+    static ma_aaudio_usage gMiniaudioAaudioUsage = ma_aaudio_usage_media;
+    static ma_aaudio_content_type gMiniaudioAaudioContentType = ma_aaudio_content_type_music;
+
+    void miniaudio_setAndroidAudioAttributes(bool aManaged)
+    {
+        gMiniaudioAaudioUsage =
+            aManaged ? ma_aaudio_usage_media : ma_aaudio_usage_default;
+        gMiniaudioAaudioContentType =
+            aManaged ? ma_aaudio_content_type_music : ma_aaudio_content_type_default;
+    }
 }
 
 #if !defined(WITH_MINIAUDIO)
@@ -404,12 +423,17 @@ namespace SoLoud
         
 #elif defined(__ANDROID__)
         // When low-latency is disabled the device runs on the legacy mixer path
-        // (set above). Also tag the AAudio stream as media/music and explicitly
-        // allow capture so system screen recorders pick up the audio.
+        // (set above). Tag the AAudio stream with the configured usage/contentType
+        // (media/music by default; left unset when the app opts to manage
+        // AudioAttributes externally via audio_session — see
+        // miniaudio_setAndroidAudioAttributes) and explicitly allow capture so
+        // system screen recorders pick up the audio. miniaudio skips the setter
+        // for `_default`, so opting out truly leaves the attributes untouched.
+        // The same globals are re-applied on device changes (changeDevice_impl).
         if (!gMiniaudioLowLatency)
         {
-            deviceConfig.aaudio.usage                = ma_aaudio_usage_media;
-            deviceConfig.aaudio.contentType          = ma_aaudio_content_type_music;
+            deviceConfig.aaudio.usage                = gMiniaudioAaudioUsage;
+            deviceConfig.aaudio.contentType          = gMiniaudioAaudioContentType;
             deviceConfig.aaudio.allowedCapturePolicy = ma_aaudio_allow_capture_by_all;
         }
 
@@ -560,8 +584,14 @@ namespace SoLoud
 #if defined(__ANDROID__)
         if (!gMiniaudioLowLatency)
         {
-            deviceConfig.aaudio.usage                = ma_aaudio_usage_media;
-            deviceConfig.aaudio.contentType          = ma_aaudio_content_type_music;
+            // Re-apply the SAME attributes chosen at init so a device change
+            // doesn't silently revert them. If the app opted out
+            // (miniaudio_setAndroidAudioAttributes(false)), these are `_default`
+            // and miniaudio leaves them unset — so an externally-managed
+            // configuration (e.g. via audio_session) is preserved across device
+            // changes rather than being forced back to media/music.
+            deviceConfig.aaudio.usage                = gMiniaudioAaudioUsage;
+            deviceConfig.aaudio.contentType          = gMiniaudioAaudioContentType;
             deviceConfig.aaudio.allowedCapturePolicy = ma_aaudio_allow_capture_by_all;
         }
 #endif

--- a/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
+++ b/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
@@ -30,6 +30,23 @@ distribution.
 #include <unistd.h>
 #endif
 
+namespace SoLoud
+{
+    // Selects the miniaudio performance profile used when (re)initializing the
+    // device. Low-latency (the historical default) maps to AAudio's
+    // PERFORMANCE_MODE_LOW_LATENCY / MMAP path on Android; that path can't be
+    // captured by system screen recorders and leaves little callback headroom
+    // for CPU-heavy filters. When this is false, the conservative (legacy
+    // mixer) profile is used instead. Defined outside the WITH_MINIAUDIO guard
+    // so the setter symbol always exists for the C bindings to call.
+    static bool gMiniaudioLowLatency = true;
+
+    void miniaudio_setLowLatency(bool aLowLatency)
+    {
+        gMiniaudioLowLatency = aLowLatency;
+    }
+}
+
 #if !defined(WITH_MINIAUDIO)
 
 namespace SoLoud
@@ -331,6 +348,13 @@ namespace SoLoud
         // deviceConfig.aaudio.inputPreset = ma_aaudio_input_preset_default;
         deviceConfig.notificationCallback = on_notification;
 
+        // Honor the requested performance profile (see gMiniaudioLowLatency).
+        // Conservative keeps Android off the un-capturable MMAP path and gives
+        // heavy DSP more headroom; the trade-off is higher output latency.
+        deviceConfig.performanceProfile = gMiniaudioLowLatency
+            ? ma_performance_profile_low_latency
+            : ma_performance_profile_conservative;
+
 #ifdef _WIN32
         // On Windows, defer the entire device initialization to avoid interfering with
         // the main thread's message pump. This fixes compatibility with plugins like
@@ -379,6 +403,16 @@ namespace SoLoud
         gDeviceStartDeferred = false;
         
 #elif defined(__ANDROID__)
+        // When low-latency is disabled the device runs on the legacy mixer path
+        // (set above). Also tag the AAudio stream as media/music and explicitly
+        // allow capture so system screen recorders pick up the audio.
+        if (!gMiniaudioLowLatency)
+        {
+            deviceConfig.aaudio.usage                = ma_aaudio_usage_media;
+            deviceConfig.aaudio.contentType          = ma_aaudio_content_type_music;
+            deviceConfig.aaudio.allowedCapturePolicy = ma_aaudio_allow_capture_by_all;
+        }
+
         ma_backend backends[] = { ma_backend_aaudio, ma_backend_opensl };
         ma_uint32 backendCount = 2;
         if (android_get_device_api_level() <= 29) {
@@ -516,6 +550,21 @@ namespace SoLoud
         deviceConfig.dataCallback       = soloud_miniaudio_audiomixer;
         deviceConfig.pUserData          = (void *)soloud;
         deviceConfig.notificationCallback = on_notification;
+
+        // Preserve the performance profile chosen at init across device changes,
+        // otherwise switching the output device would silently revert to the
+        // default low-latency/MMAP path (see gMiniaudioLowLatency).
+        deviceConfig.performanceProfile = gMiniaudioLowLatency
+            ? ma_performance_profile_low_latency
+            : ma_performance_profile_conservative;
+#if defined(__ANDROID__)
+        if (!gMiniaudioLowLatency)
+        {
+            deviceConfig.aaudio.usage                = ma_aaudio_usage_media;
+            deviceConfig.aaudio.contentType          = ma_aaudio_content_type_music;
+            deviceConfig.aaudio.allowedCapturePolicy = ma_aaudio_allow_capture_by_all;
+        }
+#endif
 
         ma_result result;
 #if defined(MA_HAS_COREAUDIO) || defined(__ANDROID__)


### PR DESCRIPTION
## Description

`init()` always opened the playback device with miniaudio's default low-latency performance profile. On Android that maps to AAUDIO_PERFORMANCE_MODE_LOW_LATENCY and takes AAudio's MMAP/exclusive path, which has two surprising consequences:

  1. It bypasses the AudioFlinger mixer that system screen recorders tap, so app audio is silent in screen recordings.
  2. Its tiny, tight-deadline callbacks starve CPU-heavy filters (such as the FFT pitch shift), producing audible dropouts.

This adds an opt-in `bool lowLatency = true` parameter to `init()`. The default preserves the existing behavior on every platform, so this is hopefully non-breaking. When set to `false`, the device is opened with the conservative (legacy mixer) profile; on Android the stream is also tagged MEDIA/MUSIC with capture explicitly allowed. The result is output that screen recorders can capture and that gives heavy DSP enough headroom to run cleanly, at the cost of higher output latency.

The flag is threaded init() -> initEngine() (FFI) -> Player::init() -> SoLoud::miniaudio_setLowLatency() and consumed in miniaudio_init(), avoiding any change to the vendored SoLoud core's init() signature. The Web backend accepts and ignores the flag.

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
