### PR TITLE
feat: add an isolate-safe singleton for running mixer output capture

### DIFF
--- a/example/.metadata
+++ b/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "e1fd963c6f6922bd32afde2e9698a363cd0406d2"
+  revision: "ad70ec4617166f1c38e5d2bfd388af71fda14f06"
   channel: "stable"
 
 project_type: app
@@ -13,11 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: e1fd963c6f6922bd32afde2e9698a363cd0406d2
-      base_revision: e1fd963c6f6922bd32afde2e9698a363cd0406d2
-    - platform: ios
-      create_revision: e1fd963c6f6922bd32afde2e9698a363cd0406d2
-      base_revision: e1fd963c6f6922bd32afde2e9698a363cd0406d2
+      create_revision: ad70ec4617166f1c38e5d2bfd388af71fda14f06
+      base_revision: ad70ec4617166f1c38e5d2bfd388af71fda14f06
+    - platform: macos
+      create_revision: ad70ec4617166f1c38e5d2bfd388af71fda14f06
+      base_revision: ad70ec4617166f1c38e5d2bfd388af71fda14f06
 
   # User provided section
 

--- a/example/lib/mixer_capture/isolate_capture_test.dart
+++ b/example/lib/mixer_capture/isolate_capture_test.dart
@@ -181,7 +181,6 @@ Future<void> _captureIsolate(SendPort mainSendPort) async {
       if (message == 'stop') {
         await subscription?.cancel();
         SoLoudIsolate.instance.stopMixerOutputStream();
-        // Do NOT deinit the engine here; the main isolate owns it.
       }
     });
 

--- a/example/lib/mixer_capture/isolate_capture_test.dart
+++ b/example/lib/mixer_capture/isolate_capture_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print, experimental_member_use
 
 import 'dart:async';
 import 'dart:developer' as dev;
@@ -7,8 +7,6 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_soloud/flutter_soloud.dart';
-// ignore: implementation_imports
-import 'package:flutter_soloud/src/bindings/soloud_controller_ffi.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -147,8 +145,9 @@ class _IsolateCaptureTestState extends State<IsolateCaptureTest> {
 }
 
 /// Runs inside a separate isolate. The SoLoud engine is already initialized in
-/// C++ land by the main isolate, so here we just create a new FFI controller,
-/// register callbacks, and listen to the capture stream.
+/// C++ land by the main isolate, so here we just use [SoLoudIsolate.instance]
+/// to listen to the capture stream without touching the main isolate's
+/// callbacks, filters, or loader state.
 @pragma('vm:entry-point')
 Future<void> _captureIsolate(SendPort mainSendPort) async {
   final isolateReceivePort = ReceivePort();
@@ -156,35 +155,22 @@ Future<void> _captureIsolate(SendPort mainSendPort) async {
 
   void send(String message) => mainSendPort.send(message);
 
+  StreamSubscription<Uint8List>? subscription;
+
   try {
-    send('Isolate: creating FFI controller...');
+    send('Isolate: starting mixer output capture via SoLoudIsolate...');
 
-    final controller = SoLoudController();
-    final bindings = controller.soLoudFFI;
-
-    await bindings.setDartEventCallbacks();
-
-    send('Isolate: starting mixer output capture...');
-    final captureResult = bindings.startMixerOutputCapture(
-      MixerOutputFormat.pcmS16le,
-      -1,
-      -1,
-      1024 * 1024,
-      4096,
-      2048, // fixed PCM chunk
+    final captureStream = SoLoudIsolate.instance.startMixerOutputStream(
+      format: MixerOutputFormat.pcmS16le,
+      chunkPCMFrames: 2048, // fixed PCM chunk
     );
-    if (captureResult.value != 0) {
-      send('Isolate: startMixerOutputCapture failed: '
-          'code ${captureResult.value}');
-      return;
-    }
 
     var chunkCount = 0;
 
-    final subscription = bindings.mixerOutputChunkEvents.listen(
+    subscription = captureStream.listen(
       (Uint8List chunk) {
         chunkCount++;
-        if (chunkCount % 10 == 0) {
+        if (chunkCount % 5 == 0) {
           print('Isolate: chunk #$chunkCount - ${chunk.length} bytes');
         }
       },
@@ -193,18 +179,19 @@ Future<void> _captureIsolate(SendPort mainSendPort) async {
     print('Isolate: capturing...');
     isolateReceivePort.listen((message) async {
       if (message == 'stop') {
-        await subscription.cancel();
-        bindings.stopMixerOutputCapture();
+        await subscription?.cancel();
+        SoLoudIsolate.instance.stopMixerOutputStream();
         // Do NOT deinit the engine here; the main isolate owns it.
       }
     });
-
 
     send(
       'Isolate: done. Continue to listen to capture stream until '
       'main isolate stops us.',
     );
   } on Object catch (e, stackTrace) {
+    await subscription?.cancel();
+    SoLoudIsolate.instance.stopMixerOutputStream();
     send('Isolate: error: $e');
     send(stackTrace.toString());
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -440,42 +440,42 @@ packages:
     dependency: transitive
     description:
       name: sqflite
-      sha256: "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a"
+      sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+1"
+    version: "2.4.3"
   sqflite_android:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+3"
+    version: "2.4.3"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465"
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.8"
+    version: "2.5.11"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
       name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   stack_trace:
     dependency: transitive
     description:
@@ -504,10 +504,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5"
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.0+1"
+    version: "3.4.1"
   term_glyph:
     dependency: transitive
     description:
@@ -621,5 +621,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/lib/flutter_soloud.dart
+++ b/lib/flutter_soloud.dart
@@ -10,6 +10,7 @@ export 'src/helpers/playback_device.dart';
 export 'src/metadata.dart';
 export 'src/mixing_bus.dart';
 export 'src/soloud.dart';
+export 'src/soloud_isolate.dart';
 export 'src/sound_handle.dart';
 export 'src/sound_hash.dart';
 export 'src/tools/soloud_tools.dart';

--- a/lib/src/bindings/bindings_player.dart
+++ b/lib/src/bindings/bindings_player.dart
@@ -81,6 +81,16 @@ abstract class FlutterSoLoud {
   Stream<Uint8List> get mixerOutputChunkEvents =>
       mixerOutputChunkController.stream;
 
+  /// Register the mixer output callback so that this isolate's
+  /// [mixerOutputChunkEvents] stream receives copied chunks.
+  ///
+  /// This is intended for non-main isolates that want to start capture after
+  /// the engine has been initialized in the main isolate. It does not touch the
+  /// voice-ended, file-loaded, or state-changed callbacks, which must remain
+  /// owned by the main isolate. Implementations must be idempotent.
+  @mustBeOverridden
+  void registerMixerOutputCallback();
+
   /// Start capturing the master mixer output.
   ///
   /// [format] the desired output format.

--- a/lib/src/bindings/bindings_player_ffi.dart
+++ b/lib/src/bindings/bindings_player_ffi.dart
@@ -260,6 +260,15 @@ class FlutterSoLoudFfi extends FlutterSoLoud {
     _setMixerOutputCallback(nativeMixerOutputDataCallable!.nativeFunction);
   }
 
+  @override
+  void registerMixerOutputCallback() {
+    nativeMixerOutputDataCallable ??=
+        ffi.NativeCallable<DartMixerOutputDataCallbackTFunction>.listener(
+          _mixerOutputDataCallback,
+        );
+    _setMixerOutputCallback(nativeMixerOutputDataCallable!.nativeFunction);
+  }
+
   late final _setDartEventCallbackPtr =
       _lookup<
         ffi.NativeFunction<

--- a/lib/src/bindings/bindings_player_web.dart
+++ b/lib/src/bindings/bindings_player_web.dart
@@ -98,6 +98,15 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     });
   }
 
+  @override
+  void registerMixerOutputCallback() {
+    // On the web there is no separate isolate boundary, so we just ensure the
+    // worker-based event plumbing (including the mixer output callback) is set
+    // up. This is idempotent and safe to call from any place that needs to
+    // listen to [mixerOutputChunkEvents].
+    setDartEventCallbacks();
+  }
+
   void _handleWorkerMessage(Map<dynamic, dynamic> message) {
     final msg = message['message'] as String?;
     if (msg == null) return;

--- a/lib/src/mixer_output_stream_manager.dart
+++ b/lib/src/mixer_output_stream_manager.dart
@@ -1,0 +1,170 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_soloud/src/bindings/bindings_player.dart';
+import 'package:flutter_soloud/src/enums.dart';
+import 'package:flutter_soloud/src/exceptions/exceptions.dart';
+import 'package:meta/meta.dart';
+
+/// Internal helper that owns the mixer output capture stream lifecycle.
+///
+/// This class is used by both SoLoud (main isolate) and SoLoudIsolate
+/// (worker isolates) so the capture logic lives in a single place. It is
+/// parameterized with the [FlutterSoLoud] backend to use and a readiness
+/// predicate that decides whether the engine is in a state where capture can
+/// start.
+@internal
+class MixerOutputStreamManager {
+  MixerOutputStreamManager({required this.bindings, required this.isReady});
+
+  /// The platform-specific bindings used to start/stop capture and read the
+  /// circular buffer.
+  final FlutterSoLoud bindings;
+
+  /// Called before starting capture. Should return `true` when the native
+  /// engine is initialized and ready to capture.
+  final bool Function() isReady;
+
+  /// Subscription that forwards copied mixer output chunks to the broadcast
+  /// stream.
+  StreamSubscription<Uint8List>? _subscription;
+
+  /// The broadcast stream of captured mixer output data.
+  StreamController<Uint8List>? _streamController;
+
+  /// Captures the master mixer output as a [Stream] of [Uint8List] chunks.
+  ///
+  /// The signature mirrors SoLoud.startMixerOutputStream. See the public
+  /// documentation there for parameter details.
+  Stream<Uint8List> start({
+    MixerOutputFormat format = MixerOutputFormat.pcmF32le,
+    int sampleRate = -1,
+    int channels = -1,
+    int bufferSizeBytes = 1024 * 1024,
+    int notificationThresholdBytes = 4096,
+    int chunkPCMFrames = -1,
+  }) {
+    if (!isReady()) {
+      throw const SoLoudNotInitializedException();
+    }
+
+    if (format.isPcm) {
+      assert(
+        chunkPCMFrames == -1 || chunkPCMFrames >= 2048,
+        'chunkPCMFrames must be at least 2048 when provided',
+      );
+    } else {
+      assert(
+        chunkPCMFrames == -1,
+        'chunkPCMFrames is only supported for PCM formats',
+      );
+    }
+
+    if (_streamController != null) {
+      return _streamController!.stream;
+    }
+
+    _streamController = StreamController<Uint8List>.broadcast();
+
+    // Ensure the mixer output callback is registered in this isolate so that
+    // [bindings.mixerOutputChunkEvents] receives the copied chunks. On FFI
+    // this creates a native callable for the current isolate; on web it is a
+    // no-op because the worker plumbing is already shared. Calling this before
+    // [startMixerOutputCapture] is safe and idempotent.
+    bindings.registerMixerOutputCallback();
+
+    final error = bindings.startMixerOutputCapture(
+      format,
+      sampleRate,
+      channels,
+      bufferSizeBytes,
+      notificationThresholdBytes,
+      chunkPCMFrames,
+    );
+
+    if (error != PlayerErrors.noError) {
+      _streamController!.close();
+      _streamController = null;
+      throw SoLoudCppException.fromPlayerError(error);
+    }
+
+    _subscription = bindings.mixerOutputChunkEvents.listen(_emitChunk);
+
+    return _streamController!.stream;
+  }
+
+  void _emitChunk(Uint8List chunk) {
+    final controller = _streamController;
+    if (controller == null || controller.isClosed) {
+      return;
+    }
+
+    if (chunk.isEmpty) {
+      return;
+    }
+
+    controller.add(chunk);
+  }
+
+  /// Stops the mixer output capture stream and releases associated resources.
+  void stop() {
+    _subscription?.cancel();
+    _subscription = null;
+    bindings.stopMixerOutputCapture();
+
+    // Flush any captured data that did not reach the notification threshold.
+    // The native side keeps the buffer alive after stopping so we can copy the
+    // tail synchronously and avoid losing compressed-format headers.
+    _flushRemaining();
+
+    _streamController?.close();
+    _streamController = null;
+  }
+
+  void _flushRemaining() {
+    final controller = _streamController;
+    if (controller == null || controller.isClosed) {
+      return;
+    }
+
+    final available = bindings.getMixerOutputAvailableBytes();
+    if (available <= 0) {
+      return;
+    }
+
+    final bufferSize = bindings.getMixerOutputBufferSize();
+    final readOffset = bindings.getMixerOutputReadOffset();
+    final firstLength = available < bufferSize - readOffset
+        ? available
+        : bufferSize - readOffset;
+
+    if (firstLength > 0) {
+      final chunk = bindings.copyMixerOutputBuffer(readOffset, firstLength);
+      if (chunk.isNotEmpty) {
+        controller.add(chunk);
+      }
+    }
+
+    if (available > firstLength) {
+      final secondLength = available - firstLength;
+      final chunk = bindings.copyMixerOutputBuffer(0, secondLength);
+      if (chunk.isNotEmpty) {
+        controller.add(chunk);
+      }
+    }
+  }
+
+  /// Whether mixer output capture is currently active.
+  bool get isRunning => bindings.isMixerOutputCaptureRunning();
+
+  /// Returns the current 44-byte WAV header for the active mixer output
+  /// capture, or an empty [Uint8List] if unavailable.
+  Uint8List getWavHeader() {
+    if (!isReady()) {
+      throw const SoLoudNotInitializedException();
+    }
+    return bindings.getMixerOutputWavHeader();
+  }
+}

--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -14,6 +14,7 @@ import 'package:flutter_soloud/src/exceptions/exceptions.dart';
 import 'package:flutter_soloud/src/filters/filters.dart';
 import 'package:flutter_soloud/src/helpers/playback_device.dart';
 import 'package:flutter_soloud/src/metadata.dart';
+import 'package:flutter_soloud/src/mixer_output_stream_manager.dart';
 import 'package:flutter_soloud/src/mixing_bus.dart';
 import 'package:flutter_soloud/src/sound_handle.dart';
 import 'package:flutter_soloud/src/sound_hash.dart';
@@ -267,7 +268,7 @@ interface class SoLoud {
 
   /// The current status of the engine. This is `true` when the engine
   /// has been initialized and is immediately ready.
-  /// 
+  ///
   /// It will be always true if checking from another isolate than the main
   /// isolate. This is because it is supposed the user has already initialized
   /// the engine in the main isolate, and the engine is a singleton in C++ land.
@@ -825,16 +826,17 @@ interface class SoLoud {
         });
   }
 
+  /// Manager for the mixer output capture stream. It is intentionally separate
+  /// from the public API so that the same logic can be reused by
+  /// SoLoudIsolate from non-main isolates.
+  late final _mixerOutputStreamManager = MixerOutputStreamManager(
+    bindings: _controller.soLoudFFI,
+    isReady: () => isInitialized,
+  );
+
   ////////////////////////////////////////////////////////////////////
   // Mixer output capture
   ////////////////////////////////////////////////////////////////////
-
-  /// Subscription that reads mixer output data from the native circular
-  /// buffer and emits it through [startMixerOutputStream].
-  StreamSubscription<Uint8List>? _mixerOutputSubscription;
-
-  /// The broadcast stream of captured mixer output data.
-  StreamController<Uint8List>? _mixerOutputStreamController;
 
   /// Captures the master mixer output as a [Stream] of [Uint8List] chunks.
   ///
@@ -877,122 +879,22 @@ interface class SoLoud {
     int bufferSizeBytes = 1024 * 1024,
     int notificationThresholdBytes = 4096,
     int chunkPCMFrames = -1,
-  }) {
-    if (!isInitialized) {
-      throw const SoLoudNotInitializedException();
-    }
-
-    if (format.isPcm) {
-      assert(
-        chunkPCMFrames == -1 || chunkPCMFrames >= 2048,
-        'chunkPCMFrames must be at least 2048 when provided',
-      );
-    } else {
-      assert(
-        chunkPCMFrames == -1,
-        'chunkPCMFrames is only supported for PCM formats',
-      );
-    }
-
-    if (_mixerOutputStreamController != null) {
-      return _mixerOutputStreamController!.stream;
-    }
-
-    _mixerOutputStreamController = StreamController<Uint8List>.broadcast();
-
-    final error = _controller.soLoudFFI.startMixerOutputCapture(
-      format,
-      sampleRate,
-      channels,
-      bufferSizeBytes,
-      notificationThresholdBytes,
-      chunkPCMFrames,
-    );
-
-    if (error != PlayerErrors.noError) {
-      _mixerOutputStreamController!.close();
-      _mixerOutputStreamController = null;
-      throw SoLoudCppException.fromPlayerError(error);
-    }
-
-    _mixerOutputSubscription = _controller.soLoudFFI.mixerOutputChunkEvents
-        .listen(_emitMixerOutputChunk);
-
-    return _mixerOutputStreamController!.stream;
-  }
-
-  void _emitMixerOutputChunk(Uint8List chunk) {
-    if (_mixerOutputStreamController == null ||
-        _mixerOutputStreamController!.isClosed) {
-      return;
-    }
-
-    if (chunk.isEmpty) {
-      return;
-    }
-
-    _mixerOutputStreamController!.add(chunk);
-  }
+  }) => _mixerOutputStreamManager.start(
+    format: format,
+    sampleRate: sampleRate,
+    channels: channels,
+    bufferSizeBytes: bufferSizeBytes,
+    notificationThresholdBytes: notificationThresholdBytes,
+    chunkPCMFrames: chunkPCMFrames,
+  );
 
   /// Stops the mixer output capture stream and releases associated resources.
   @experimental
-  void stopMixerOutputStream() {
-    _mixerOutputSubscription?.cancel();
-    _mixerOutputSubscription = null;
-    _controller.soLoudFFI.stopMixerOutputCapture();
-
-    // Flush any captured data that did not reach the notification threshold.
-    // The native side keeps the buffer alive after stopping so we can copy the
-    // tail synchronously and avoid losing compressed-format headers.
-    _flushRemainingMixerOutput();
-
-    _mixerOutputStreamController?.close();
-    _mixerOutputStreamController = null;
-  }
-
-  void _flushRemainingMixerOutput() {
-    final controller = _mixerOutputStreamController;
-    if (controller == null || controller.isClosed) {
-      return;
-    }
-
-    final available = _controller.soLoudFFI.getMixerOutputAvailableBytes();
-    if (available <= 0) {
-      return;
-    }
-
-    final bufferSize = _controller.soLoudFFI.getMixerOutputBufferSize();
-    final readOffset = _controller.soLoudFFI.getMixerOutputReadOffset();
-    final firstLength = available < bufferSize - readOffset
-        ? available
-        : bufferSize - readOffset;
-
-    if (firstLength > 0) {
-      final chunk = _controller.soLoudFFI.copyMixerOutputBuffer(
-        readOffset,
-        firstLength,
-      );
-      if (chunk.isNotEmpty) {
-        controller.add(chunk);
-      }
-    }
-
-    if (available > firstLength) {
-      final secondLength = available - firstLength;
-      final chunk = _controller.soLoudFFI.copyMixerOutputBuffer(
-        0,
-        secondLength,
-      );
-      if (chunk.isNotEmpty) {
-        controller.add(chunk);
-      }
-    }
-  }
+  void stopMixerOutputStream() => _mixerOutputStreamManager.stop();
 
   /// Whether mixer output capture is currently active.
   @experimental
-  bool get isMixerOutputStreamRunning =>
-      _controller.soLoudFFI.isMixerOutputCaptureRunning();
+  bool get isMixerOutputStreamRunning => _mixerOutputStreamManager.isRunning;
 
   /// Returns the current 44-byte WAV header for the active mixer output
   /// capture.
@@ -1010,10 +912,7 @@ interface class SoLoud {
   /// is unavailable.
   @experimental
   Uint8List getMixerOutputWavHeader() {
-    if (!isInitialized) {
-      throw const SoLoudNotInitializedException();
-    }
-    return _controller.soLoudFFI.getMixerOutputWavHeader();
+    return _mixerOutputStreamManager.getWavHeader();
   }
 
   /// Set up an audio stream.

--- a/lib/src/soloud_isolate.dart
+++ b/lib/src/soloud_isolate.dart
@@ -110,9 +110,10 @@ class SoLoudIsolate {
   /// Read samples from file and memory.
   ///////////////////////////////////////////////////
 
-  /// This method has the same behavior as [SoLoud.readSamplesFromFile] and
-  /// can be safely called from a non-main isolate. Is not mandatory that the
-  /// engine is initialized in the main isolate to use this method.
+  /// This method has the same behavior as [SoLoud.readSamplesFromFile] (refer
+  /// to it for a complete documentation) and can be safely called from a
+  /// non-main isolate. Is not mandatory that the engine is initialized in
+  /// the main isolate to use this method.
   ///
   /// See also [readSamplesFromMem].
   Future<Float32List> readSamplesFromFile(
@@ -136,9 +137,10 @@ class SoLoudIsolate {
     );
   }
 
-  /// This method has the same behavior as [SoLoud.readSamplesFromMem] and
-  /// can be safely called from a non-main isolate. Is not mandatory that the
-  /// engine is initialized in the main isolate to use this method.
+  /// This method has the same behavior as [SoLoud.readSamplesFromMem] (refer
+  /// to it for a complete documentation) and can be safely called from a
+  /// non-main isolate. Is not mandatory that the engine is initialized in
+  /// the main isolate to use this method.
   ///
   /// See also [readSamplesFromFile].
   Future<Float32List> readSamplesFromMem(

--- a/lib/src/soloud_isolate.dart
+++ b/lib/src/soloud_isolate.dart
@@ -36,6 +36,9 @@ import 'package:meta/meta.dart';
 /// );
 /// isolateCapture.listen((chunk) { /* process audio bytes */ });
 /// ```
+///
+/// See also the `example/lib/mixer_capture/isolate_capture_test.dart` for
+/// a complete example of running mixer output capture in a separate isolate.
 @experimental
 class SoLoudIsolate {
   SoLoudIsolate._();
@@ -101,5 +104,63 @@ class SoLoudIsolate {
   @experimental
   Uint8List getMixerOutputWavHeader() {
     return _mixerOutputStreamManager.getWavHeader();
+  }
+
+  ///////////////////////////////////////////////////
+  /// Read samples from file and memory.
+  ///////////////////////////////////////////////////
+
+  /// This method has the same behavior as [SoLoud.readSamplesFromFile] and
+  /// can be safely called from a non-main isolate. Is not mandatory that the
+  /// engine is initialized in the main isolate to use this method.
+  ///
+  /// See also [readSamplesFromMem].
+  Future<Float32List> readSamplesFromFile(
+    String completeFileName,
+    int numSamplesNeeded, {
+    double startTime = 0,
+    double endTime = -1,
+    bool average = false,
+  }) async {
+    assert(
+      endTime == -1 || endTime > startTime,
+      '[endTime] must be greater than [startTime].',
+    );
+    assert(startTime >= 0, '[startTime] must be greater than or equal to 0.');
+    return bindings.readSamplesFromFile(
+      completeFileName,
+      numSamplesNeeded,
+      startTime: startTime,
+      endTime: endTime,
+      average: average,
+    );
+  }
+
+  /// This method has the same behavior as [SoLoud.readSamplesFromMem] and
+  /// can be safely called from a non-main isolate. Is not mandatory that the
+  /// engine is initialized in the main isolate to use this method.
+  ///
+  /// See also [readSamplesFromFile].
+  Future<Float32List> readSamplesFromMem(
+    Uint8List buffer,
+    int numSamplesNeeded, {
+    double startTime = 0,
+    double endTime = -1,
+    bool average = false,
+  }) async {
+    assert(
+      endTime == -1 || endTime > startTime,
+      '[endTime] must be greater than [startTime].',
+    );
+    assert(startTime >= 0, '[startTime] must be greater than or equal to 0.');
+    final samples = bindings.readSamplesFromMem(
+      buffer,
+      numSamplesNeeded,
+      startTime: startTime,
+      endTime: endTime,
+      average: average,
+    );
+
+    return samples;
   }
 }

--- a/lib/src/soloud_isolate.dart
+++ b/lib/src/soloud_isolate.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_soloud/src/audio_source.dart';
+import 'package:flutter_soloud/src/bindings/bindings_player.dart';
+import 'package:flutter_soloud/src/bindings/soloud_controller.dart';
+import 'package:flutter_soloud/src/enums.dart';
+import 'package:flutter_soloud/src/mixer_output_stream_manager.dart';
+import 'package:flutter_soloud/src/soloud.dart';
+import 'package:flutter_soloud/src/utils/loader.dart';
+import 'package:meta/meta.dart';
+
+/// Isolate-safe access to the SoLoud engine for tasks that do not require the
+/// main isolate's state.
+///
+/// The SoLoud engine is a singleton in C++ land and can be initialized only
+/// from the main isolate via [SoLoud]. Call `SoLoud.instance.init` in the
+/// main isolate before using this class from another isolate. Once initialized,
+/// operations can be safely performed from another isolate because they do not
+/// touch the main isolate's [SoLoudLoader], [AudioSource] registry, filters, or
+/// playback-event streams.
+///
+/// [SoLoudIsolate] exposes only those operations. It does not expose
+/// `init()`/`deinit()`, loading, playback, filters, or the
+/// `voiceEnded`/`fileLoaded`/`stateChanged` event streams. Those must remain on
+/// the isolate that initialized the engine.
+///
+/// The primary use case is running the mixer output capture stream in a worker
+/// isolate so the main isolate stays free for UI and other tasks.
+///
+/// Example:
+/// ```dart
+/// final isolateCapture = SoLoudIsolate.instance.startMixerOutputStream(
+///   format: MixerOutputFormat.pcmS16le,
+///   chunkPCMFrames: 2048,
+/// );
+/// isolateCapture.listen((chunk) { /* process audio bytes */ });
+/// ```
+@experimental
+class SoLoudIsolate {
+  SoLoudIsolate._();
+
+  /// The singleton instance of [SoLoudIsolate].
+  static final SoLoudIsolate instance = SoLoudIsolate._();
+
+  final _controller = SoLoudController();
+
+  /// The low-level platform bindings. Advanced users can use this to call
+  /// methods that are safe to invoke from a non-main isolate.
+  FlutterSoLoud get bindings => _controller.soLoudFFI;
+
+  /// Whether the native engine is initialized.
+  ///
+  /// This is `true` when [SoLoud] has been initialized in the main isolate via
+  /// `SoLoud.instance.init` and the engine is still active. It intentionally
+  /// does not depend on the main isolate's loader or callback state.
+  bool get isInitialized => bindings.isInited();
+
+  late final _mixerOutputStreamManager = MixerOutputStreamManager(
+    bindings: bindings,
+    isReady: () => isInitialized,
+  );
+
+  /// Captures the master mixer output as a [Stream] of [Uint8List] chunks.
+  ///
+  /// This method has the same behavior as [SoLoud.startMixerOutputStream] but
+  /// can be called from a non-main isolate. The engine must have been
+  /// initialized in the main isolate before calling this method.
+  ///
+  /// See [SoLoud.startMixerOutputStream] for parameter details.
+  @experimental
+  Stream<Uint8List> startMixerOutputStream({
+    MixerOutputFormat format = MixerOutputFormat.pcmF32le,
+    int sampleRate = -1,
+    int channels = -1,
+    int bufferSizeBytes = 1024 * 1024,
+    int notificationThresholdBytes = 4096,
+    int chunkPCMFrames = -1,
+  }) => _mixerOutputStreamManager.start(
+    format: format,
+    sampleRate: sampleRate,
+    channels: channels,
+    bufferSizeBytes: bufferSizeBytes,
+    notificationThresholdBytes: notificationThresholdBytes,
+    chunkPCMFrames: chunkPCMFrames,
+  );
+
+  /// Stops the mixer output capture stream and releases associated resources.
+  @experimental
+  void stopMixerOutputStream() => _mixerOutputStreamManager.stop();
+
+  /// Whether mixer output capture is currently active.
+  @experimental
+  bool get isMixerOutputStreamRunning => _mixerOutputStreamManager.isRunning;
+
+  /// Returns the current 44-byte WAV header for the active mixer output
+  /// capture.
+  ///
+  /// This is only meaningful when the capture format is
+  /// [MixerOutputFormat.wav]. See [SoLoud.getMixerOutputWavHeader] for details.
+  @experimental
+  Uint8List getMixerOutputWavHeader() {
+    return _mixerOutputStreamManager.getWavHeader();
+  }
+}


### PR DESCRIPTION
## Description

`SoLoud.instance` cannot be used from another isolate because its `isInitialized` check depends on main-isolate state (`_loader`, `_activeSounds`, callbacks, etc.). The native engine is isolate-agnostic, so the new class `SoLoudIsolate` wraps `SoLoudController` and exposes only the safe subset of operations.

`SoLoudIsolate` is an isolate-safe singleton for running mixer output capture (and other safe operations, for now only `readSamplesFrom*`) from a non-main isolate without touching the main isolate's loader, filters, or event callbacks.

## Changes
- Added `registerMixerOutputCallback()` to `FlutterSoLoud` so worker isolates can receive mixer output chunks without calling `setDartEventCallbacks()`.
- Introduced `MixerOutputStreamManager` to share the capture stream logic between `SoLoud` and `SoLoudIsolate`.
- Updated `example/lib/mixer_capture/isolate_capture_test.dart` to use `SoLoudIsolate.instance`.

/cc @Slashpaf

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)