### PR TITLE
fix: Waveform audio sources do not match engine sample rate

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -694,7 +694,9 @@ PlayerErrors Player::loadWaveform(
         sounds.push_back(std::make_unique<ActiveSound>());
         sounds.back().get()->completeFileName = "";
         sounds.back().get()->soundHash = hash;
-        sounds.back().get()->sound = std::make_unique<Basicwave>((SoLoud::Soloud::WAVEFORM)waveform, superWave, detune, scale);
+        auto basicWave = std::make_unique<Basicwave>((SoLoud::Soloud::WAVEFORM)waveform, superWave, detune, scale);
+        basicWave->setSamplerate(mSampleRate);
+        sounds.back().get()->sound = std::move(basicWave);
         sounds.back().get()->soundType = TYPE_SYNTH;
         sounds.back().get()->filters = std::make_unique<Filters>(&soloud, sounds.back().get(), nullptr);
     }


### PR DESCRIPTION
Closes https://github.com/alnitak/flutter_soloud/issues/500

## Description

When soloud is initialized at 48 kHz, waveform sources are currently still marked as 44.1 kHz, so SoLoud resamples every generated waveform voice. 

This PR sets the sample rate of waveform audio sources to match the engine, so no resampling is necessary. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
