### PR TITLE
stop() can throw uncaught "Bad state: Future already completed" when the native voiceEnded event races the internal 300 ms timeout

### DIFF
--- a/lib/src/soloud.dart
+++ b/lib/src/soloud.dart
@@ -579,7 +579,10 @@ interface class SoLoud {
             // All instances of the sound have finished.
             soundHandleFound.allInstancesFinishedController.add(null);
           }
-          voiceEndedCompleters[SoundHandle(handle)]?.complete();
+          final voiceEndedCompleter = voiceEndedCompleters[SoundHandle(handle)];
+          if (voiceEndedCompleter != null && !voiceEndedCompleter.isCompleted) {
+            voiceEndedCompleter.complete();
+          }
 
           // if there are no more handles palying and the "autoDispose"
           // parameter has been set, dispose the sound.
@@ -2320,7 +2323,7 @@ interface class SoLoud {
             'This is not expected but not blocking. Worth to file a bug with '
             'a simple reproducible code.',
           );
-          voiceEndedCompleters[handle]?.complete();
+          if (!completer.isCompleted) completer.complete();
         })
         .whenComplete(() {
           voiceEndedCompleters.removeWhere((key, __) => key == handle);


### PR DESCRIPTION
## Description

closes #507

## Type of Change

- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
