### PR TITLE
include mixer_output with relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 4.1.1 (28 Jul 2026)
+- ios SPM fix: include mixer_output with relative path #514
+
 #### 4.1.0 (28 Jul 2026)
 - added **pull-buffer streaming API** (`setPullBufferStream`, `addPullBufferDataStream`, `getPullBufferTimeRange`) with support for MP3, WAV, FLAC, Ogg Opus, Ogg Vorbis, and Ogg FLAC.
 - get rid of stb_vorbis c file in favor of the Xiph OGG libraries for Opus, Vorbis, and FLAC.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A low-level audio plugin for Flutter,
   mainly meant for games and immersive apps.
   Based on the SoLoud (C++) audio engine.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/alnitak/flutter_soloud
 maintainer: Marco Bavagnoli (@alnitak)
 platforms:

--- a/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
+++ b/src/soloud/src/backend/miniaudio/soloud_miniaudio.cpp
@@ -70,7 +70,7 @@ namespace SoLoud
 #include <thread>
 #include <mutex>
 #include "soloud_common.h"
-#include "mixeroutput/mixer_output.h"
+#include "../../../../mixeroutput/mixer_output.h"
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #else


### PR DESCRIPTION
## Description

It seems that somehow the mixer_output.h is not found when using SPM to build for iOS. Fixing using a relative path as addressed [here](https://github.com/alnitak/flutter_soloud/pull/509#issuecomment-5107793432) by @adammmckee.

## Type of Change

- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)