### PR TITLE
fix web: crash with --optimization-level=0 due to HEAPU8.buffer declared as JSArrayBuffer #521

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+##### 4.1.5 (XX Xxx 2026)
+- fix web: crash with `--optimization-level=0` due to HEAPU8.buffer declared as JSArrayBuffer #526
+
 ##### 4.1.4 (31 Jul 2026)
 - fix: the voice-ended callback is no longer invoked while SoLoud's audio mutex is held. The symptom was a wedged engine: handles and sources still looked valid, no audio was produced, and `deinit()` never completed. Ended voices are now queued and dispatched once the mutex is released. Thanks to @Colton127 #518
 - fix: on macOS/iOS, the first CocoaPods build after a clean no longer fails with "Build input file cannot be found: libflutter_soloud_plugin.a"

--- a/lib/src/bindings/audio_data_web.dart
+++ b/lib/src/bindings/audio_data_web.dart
@@ -55,23 +55,35 @@ class AudioDataCtrl {
     if (!alwaysReturnData && dataIsTheSameAsBefore || _samplesPtr == 0) {
       return Float32List(0);
     }
-    // Convert the JSArrayBuffer to a Dart Float32List
-    return wasmHeapU8Buffer.toDart.asFloat32List(_samplePtrPtr, 256);
+    // Read the floats through the HEAPF32 view of the WASM memory.
+    return Float32List.sublistView(
+      wasmHeapF32.toDart,
+      _samplePtrPtr ~/ 4,
+      (_samplePtrPtr ~/ 4) + 256,
+    );
   }
 
   Float32List getFftAndWave({bool alwaysReturnData = true}) {
     if (!alwaysReturnData && dataIsTheSameAsBefore || _samplesPtr == 0) {
       return Float32List(0);
     }
-    // Convert the JSArrayBuffer to a Dart Float32List
-    return wasmHeapU8Buffer.toDart.asFloat32List(_samplePtrPtr, 512);
+    // Read the floats through the HEAPF32 view of the WASM memory.
+    return Float32List.sublistView(
+      wasmHeapF32.toDart,
+      _samplePtrPtr ~/ 4,
+      (_samplePtrPtr ~/ 4) + 512,
+    );
   }
 
   Float32List get2DTexture({bool alwaysReturnData = true}) {
     if (!alwaysReturnData && dataIsTheSameAsBefore || _samplesPtr == 0) {
       return Float32List(0);
     }
-    // Convert the JSArrayBuffer to a Dart Float32List
-    return wasmHeapU8Buffer.toDart.asFloat32List(_samplePtrPtr, 512 * 256);
+    // Read the floats through the HEAPF32 view of the WASM memory.
+    return Float32List.sublistView(
+      wasmHeapF32.toDart,
+      _samplePtrPtr ~/ 4,
+      (_samplePtrPtr ~/ 4) + 512 * 256,
+    );
   }
 }

--- a/lib/src/bindings/bindings_player_web.dart
+++ b/lib/src/bindings/bindings_player_web.dart
@@ -132,8 +132,12 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
         // read position so the circular buffer can reuse the memory. In fixed
         // PCM chunk mode the native side already advances the read position,
         // so Dart must not advance it again.
-        final heapBuffer = wasmHeapU8Buffer;
-        final bytes = Uint8List.view(heapBuffer.toDart, offset, length);
+        final heapU8 = wasmHeapU8;
+        final bytes = Uint8List.sublistView(
+          heapU8.toDart,
+          offset,
+          offset + length,
+        );
         mixerOutputChunkController.add(Uint8List.fromList(bytes));
         if (!_mixerOutputChunkMode) {
           advanceMixerOutputReadPosition(length);
@@ -206,8 +210,8 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     if (ptr == 0) {
       return Uint8List(0);
     }
-    final heapBuffer = wasmHeapU8Buffer;
-    final bytes = Uint8List.view(heapBuffer.toDart, ptr, 44);
+    final heapU8 = wasmHeapU8;
+    final bytes = Uint8List.sublistView(heapU8.toDart, ptr, ptr + 44);
     final copy = Uint8List.fromList(bytes);
     wasmFree(ptr);
     return copy;
@@ -219,11 +223,11 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
       return Uint8List(0);
     }
     final basePointer = wasmGetMixerCaptureBufferPointer();
-    final heapBuffer = wasmHeapU8Buffer;
-    final bytes = Uint8List.view(
-      heapBuffer.toDart,
+    final heapU8 = wasmHeapU8;
+    final bytes = Uint8List.sublistView(
+      heapU8.toDart,
       basePointer + offset,
-      length,
+      basePointer + offset + length,
     );
     return Uint8List.fromList(bytes);
   }
@@ -340,8 +344,8 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     final pathPtr = wasmMalloc(uniqueName.length);
 
     /// Copy the buffer into WASM memory using the HEAPU8 view.
-    final heapBuffer = wasmHeapU8Buffer;
-    Uint8List.view(heapBuffer.toDart).setAll(bytesPtr, buffer);
+    final heapU8 = wasmHeapU8;
+    heapU8.toDart.setAll(bytesPtr, buffer);
 
     /// Copy the path string into WASM memory.
     for (var i = 0; i < uniqueName.length; i++) {
@@ -539,8 +543,8 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     scheduleMicrotask(() {
       final audioChunkPtr = wasmMalloc(chunkCopy.length);
 
-      final heapBuffer = wasmHeapU8Buffer;
-      Uint8List.view(heapBuffer.toDart).setAll(audioChunkPtr, chunkCopy);
+      final heapU8 = wasmHeapU8;
+      heapU8.toDart.setAll(audioChunkPtr, chunkCopy);
 
       try {
         wasmAddPullBufferDataStream(
@@ -609,8 +613,8 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     final audioChunkPtr = wasmMalloc(audioChunk.length);
 
     /// Copy the audio chunk into WASM memory using the HEAPU8 view.
-    final heapBuffer = wasmHeapU8Buffer;
-    Uint8List.view(heapBuffer.toDart).setAll(audioChunkPtr, audioChunk);
+    final heapU8 = wasmHeapU8;
+    heapU8.toDart.setAll(audioChunkPtr, audioChunk);
 
     final result = wasmAddAudioDataStream(
       hash,
@@ -1614,8 +1618,8 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     final bufferPtr = wasmMalloc(buffer.length);
 
     /// Copy the buffer into WASM memory using the HEAPU8 view.
-    final heapBuffer = wasmHeapU8Buffer;
-    Uint8List.view(heapBuffer.toDart).setAll(bufferPtr, buffer);
+    final heapU8 = wasmHeapU8;
+    heapU8.toDart.setAll(bufferPtr, buffer);
 
     final samplesPtr = wasmMalloc(numSamplesNeeded * 4);
     final error = wasmReadSamplesFromMem(
@@ -1629,7 +1633,7 @@ class FlutterSoLoudWeb extends FlutterSoLoud {
     );
 
     // Create a view of the WASM memory using JSFloat32Array first
-    final jsHeapF32 = wasmHeapF32Buffer;
+    final jsHeapF32 = wasmHeapF32;
     // Convert the TypedArray view to a Dart Float32List
     final samples = Float32List.sublistView(
       jsHeapF32.toDart,

--- a/lib/src/bindings/js_extension.dart
+++ b/lib/src/bindings/js_extension.dart
@@ -39,11 +39,19 @@ external double wasmGetF64Value(int ptrAddress, String type);
 @JS('Module_soloud.getValue')
 external double wasmGetF32Value(int ptrAddress, String type);
 
-@JS('Module_soloud.HEAPU8.buffer')
-external JSArrayBuffer get wasmHeapU8Buffer;
+/// The WASM heap as a [JSUint8Array].
+///
+/// NOTE: the underlying buffer (`Module_soloud.HEAPU8.buffer`) must not be
+/// declared as a `JSArrayBuffer`: the module is compiled with `-pthread` and
+/// `SHARED_MEMORY=1`, so the buffer is actually a `SharedArrayBuffer` and the
+/// implicit downcast would throw on the JS build (dart2js) whenever runtime
+/// type checks are enabled (e.g. with `--optimization-level=0`). Using the
+/// typed-array views instead works for both buffer kinds.
+@JS('Module_soloud.HEAPU8')
+external JSUint8Array get wasmHeapU8;
 
 @JS('Module_soloud.HEAPF32')
-external JSFloat32Array get wasmHeapF32Buffer;
+external JSFloat32Array get wasmHeapF32;
 
 @JS('Module_soloud.UTF8ToString')
 external String wasmUtf8ToString(int ptrAddress);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A low-level audio plugin for Flutter,
   mainly meant for games and immersive apps.
   Based on the SoLoud (C++) audio engine.
-version: 4.1.4
+version: 4.1.5
 homepage: https://github.com/alnitak/flutter_soloud
 maintainer: Marco Bavagnoli (@alnitak)
 platforms:


### PR DESCRIPTION
## Description

fixes #521

The WASM module is compiled with `-pthread` / `SHARED_MEMORY=1`, so `Module_soloud.HEAPU8.buffer` is a `SharedArrayBuffer`, not an `ArrayBuffer`. Declaring it as `JSArrayBuffer` makes the implicit downcast throw on dart2js builds whenever runtime type checks are kept (e.g. by using `--optimization-level=0`).

Access the heap through its typed-array views (`HEAPU8` as `JSUint8Array`, `HEAPF32` as `JSFloat32Array`) instead, are correct regardless of whether the backing buffer is an `ArrayBuffer` or a `SharedArrayBuffer`

## Type of Change

- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
